### PR TITLE
Remove singleton behavior from numbering

### DIFF
--- a/lib/sablon.rb
+++ b/lib/sablon.rb
@@ -1,4 +1,3 @@
-require 'singleton'
 require 'zip'
 require 'nokogiri'
 

--- a/lib/sablon/content.rb
+++ b/lib/sablon/content.rb
@@ -68,13 +68,8 @@ module Sablon
     # handles direct addition of WordML to the document template
     class WordML < Struct.new(:xml)
       include Sablon::Content
-      def self.id
-        :word_ml
-      end
-
-      def self.wraps?(_)
-        false
-      end
+      def self.id; :word_ml end
+      def self.wraps?(value) false end
 
       def append_to(paragraph, display_node, env)
         Nokogiri::XML.fragment(xml).children.reverse.each do |child|
@@ -87,13 +82,8 @@ module Sablon
     # Handles conversion of HTML -> WordML and addition into template
     class HTML < Struct.new(:html_content)
       include Sablon::Content
-      def self.id
-        :html
-      end
-
-      def self.wraps?(_)
-        false
-      end
+      def self.id; :html end
+      def self.wraps?(value) false end
 
       def initialize(value)
         super value

--- a/lib/sablon/content.rb
+++ b/lib/sablon/content.rb
@@ -52,7 +52,7 @@ module Sablon
         super value.to_s
       end
 
-      def append_to(paragraph, display_node, _env)
+      def append_to(paragraph, display_node, env)
         string.scan(/[^\n]+|\n/).reverse.each do |part|
           if part == "\n"
             display_node.add_next_sibling Nokogiri::XML::Node.new "w:br", display_node.document
@@ -76,7 +76,7 @@ module Sablon
         false
       end
 
-      def append_to(paragraph, _display_node, _env)
+      def append_to(paragraph, display_node, env)
         Nokogiri::XML.fragment(xml).children.reverse.each do |child|
           paragraph.add_next_sibling child
         end

--- a/lib/sablon/content.rb
+++ b/lib/sablon/content.rb
@@ -40,6 +40,7 @@ module Sablon
       end
     end
 
+    # Handles simple text replacement of fields in the template
     class String < Struct.new(:string)
       include Sablon::Content
       def self.id; :string end
@@ -51,7 +52,7 @@ module Sablon
         super value.to_s
       end
 
-      def append_to(paragraph, display_node)
+      def append_to(paragraph, display_node, _env)
         string.scan(/[^\n]+|\n/).reverse.each do |part|
           if part == "\n"
             display_node.add_next_sibling Nokogiri::XML::Node.new "w:br", display_node.document
@@ -64,12 +65,18 @@ module Sablon
       end
     end
 
+    # handles direct addition of WordML to the document template
     class WordML < Struct.new(:xml)
       include Sablon::Content
-      def self.id; :word_ml end
-      def self.wraps?(value) false end
+      def self.id
+        :word_ml
+      end
 
-      def append_to(paragraph, display_node)
+      def self.wraps?(_)
+        false
+      end
+
+      def append_to(paragraph, _display_node, _env)
         Nokogiri::XML.fragment(xml).children.reverse.each do |child|
           paragraph.add_next_sibling child
         end
@@ -77,19 +84,25 @@ module Sablon
       end
     end
 
-    class HTML < Struct.new(:word_ml)
+    # Handles conversion of HTML -> WordML and addition into template
+    class HTML < Struct.new(:html_content)
       include Sablon::Content
-      def self.id; :html end
-      def self.wraps?(value) false end
-
-      def initialize(html)
-        converter = HTMLConverter.new
-        word_ml = Sablon.content(:word_ml, converter.process(html))
-        super word_ml
+      def self.id
+        :html
       end
 
-      def append_to(*args)
-        word_ml.append_to(*args)
+      def self.wraps?(_)
+        false
+      end
+
+      def initialize(value)
+        super value
+      end
+
+      def append_to(paragraph, display_node, env)
+        converter = HTMLConverter.new
+        word_ml = WordML.new(converter.process(html_content, env))
+        word_ml.append_to(paragraph, display_node, env)
       end
     end
 

--- a/lib/sablon/environment.rb
+++ b/lib/sablon/environment.rb
@@ -9,14 +9,22 @@ module Sablon
     # returns a new environment with merged contexts
     def alter_context(context = {})
       new_context = @context.merge(context)
-      Environment.new(@template, new_context, @numbering)
+      Environment.new(nil, new_context, self)
     end
 
     private
 
-    def initialize(template, context = {}, numbering=nil)
-      @template = template
-      @numbering = (numbering || Sablon::Numbering.new)
+    def initialize(template, context = {}, parent_env = nil)
+      # pass attributes of the supplied environment to the new one or
+      # create new references
+      if parent_env
+        @template = parent_env.template
+        @numbering = parent_env.numbering
+      else
+        @template = template
+        @numbering = Numbering.new
+      end
+      #
       @context = Context.transform_hash(context)
     end
   end

--- a/lib/sablon/environment.rb
+++ b/lib/sablon/environment.rb
@@ -3,18 +3,20 @@ module Sablon
   # to manage data during template processing.
   class Environment
     attr_reader :template
+    attr_reader :numbering
     attr_reader :context
 
     # returns a new environment with merged contexts
     def alter_context(context = {})
       new_context = @context.merge(context)
-      Environment.new(@template, new_context)
+      Environment.new(@template, new_context, @numbering)
     end
 
     private
 
-    def initialize(template, context = {})
+    def initialize(template, context = {}, numbering=nil)
       @template = template
+      @numbering = (numbering || Sablon::Numbering.new)
       @context = Context.transform_hash(context)
     end
   end

--- a/lib/sablon/html/converter.rb
+++ b/lib/sablon/html/converter.rb
@@ -48,6 +48,7 @@ module Sablon
       end
 
       private
+
       def current_layer
         if @layers.any?
           last_layer = @layers.last
@@ -63,7 +64,8 @@ module Sablon
       end
     end
 
-    def process(input)
+    def process(input, env)
+      @numbering = env.numbering
       processed_ast(input).to_docx
     end
 
@@ -85,6 +87,10 @@ module Sablon
 
     private
 
+    def initialize
+      @numbering = nil
+    end
+
     def ast_next_paragraph
       node = @builder.next
       if node.name == 'div'
@@ -99,13 +105,13 @@ module Sablon
       elsif node.name == 'ul'
         @builder.new_layer ilvl: true
         unless @builder.nested?
-          @definition = Sablon::Numbering.instance.register('ListBullet')
+          @definition = @numbering.register('ListBullet')
         end
         @builder.push_all(node.children)
       elsif node.name == 'ol'
         @builder.new_layer ilvl: true
         unless @builder.nested?
-          @definition = Sablon::Numbering.instance.register('ListNumber')
+          @definition = @numbering.register('ListNumber')
         end
         @builder.push_all(node.children)
       elsif node.name == 'li'

--- a/lib/sablon/numbering.rb
+++ b/lib/sablon/numbering.rb
@@ -1,6 +1,5 @@
 module Sablon
   class Numbering
-    include Singleton
     attr_reader :definitions
 
     Definition = Struct.new(:numid, :style) do
@@ -10,10 +9,6 @@ module Sablon
     end
 
     def initialize
-      reset!
-    end
-
-    def reset!
       @numid = 1000
       @definitions = []
     end

--- a/lib/sablon/operations.rb
+++ b/lib/sablon/operations.rb
@@ -4,7 +4,7 @@ module Sablon
     class Insertion < Struct.new(:expr, :field)
       def evaluate(env)
         if content = expr.evaluate(env.context)
-          field.replace(Sablon::Content.wrap(content))
+          field.replace(Sablon::Content.wrap(content), env)
         else
           field.remove
         end

--- a/lib/sablon/parser/mail_merge.rb
+++ b/lib/sablon/parser/mail_merge.rb
@@ -13,10 +13,11 @@ module Sablon
         end
 
         private
-        def replace_field_display(node, content)
+
+        def replace_field_display(node, content, env)
           paragraph = node.ancestors(".//w:p").first
           display_node = get_display_node(node)
-          content.append_to(paragraph, display_node)
+          content.append_to(paragraph, display_node, env)
           display_node.remove
         end
 
@@ -35,8 +36,8 @@ module Sablon
           separate_node && get_display_node(pattern_node) && expression
         end
 
-        def replace(content)
-          replace_field_display(pattern_node, content)
+        def replace(content, env)
+          replace_field_display(pattern_node, content, env)
           (@nodes - [pattern_node]).each(&:remove)
         end
 
@@ -72,9 +73,9 @@ module Sablon
           @raw_expression = @node["w:instr"]
         end
 
-        def replace(content)
+        def replace(content, env)
           remove_extra_runs!
-          replace_field_display(@node, content)
+          replace_field_display(@node, content, env)
           @node.replace(@node.children)
         end
 

--- a/lib/sablon/processor/numbering.rb
+++ b/lib/sablon/processor/numbering.rb
@@ -7,9 +7,9 @@ module Sablon
         </w:num>
       XML
 
-      def self.process(doc)
+      def self.process(doc, env)
         processor = new(doc)
-        processor.manipulate
+        processor.manipulate env
         doc
       end
 
@@ -17,8 +17,8 @@ module Sablon
         @doc = doc
       end
 
-      def manipulate
-        Sablon::Numbering.instance.definitions.each do |definition|
+      def manipulate(env)
+        env.numbering.definitions.each do |definition|
           abstract_num_ref = find_definition(definition.style)
           abstract_num_copy = abstract_num_ref.dup
           abstract_num_copy['w:abstractNumId'] = definition.numid

--- a/lib/sablon/template.rb
+++ b/lib/sablon/template.rb
@@ -17,8 +17,8 @@ module Sablon
     end
 
     private
+
     def render(context, properties = {})
-      Sablon::Numbering.instance.reset!
       env = Sablon::Environment.new(self, context)
       Zip.sort_entries = true # required to process document.xml before numbering.xml
       Zip::OutputStream.write_buffer(StringIO.new) do |out|
@@ -31,7 +31,7 @@ module Sablon
           elsif entry_name =~ /word\/header\d*\.xml/ || entry_name =~ /word\/footer\d*\.xml/
             out.write(process(Processor::Document, content, env))
           elsif entry_name == 'word/numbering.xml'
-            out.write(process(Processor::Numbering, content))
+            out.write(process(Processor::Numbering, content, env))
           else
             out.write(content)
           end

--- a/test/content_test.rb
+++ b/test/content_test.rb
@@ -76,6 +76,7 @@ module ContentTestSetup
     @document = Nokogiri::XML.fragment(@template_text)
     @paragraph = @document.children.first
     @node = @document.css("span").first
+    @env = Sablon::Environment.new(nil)
   end
 
   private
@@ -88,7 +89,7 @@ class ContentStringTest < Sablon::TestCase
   include ContentTestSetup
 
   def test_single_line_string
-    Sablon.content(:string, "a normal string").append_to @paragraph, @node
+    Sablon.content(:string, "a normal string").append_to @paragraph, @node, @env
 
     output = <<-XML.strip
 <w:p><span>template</span><span>a normal string</span></w:p><w:p>AFTER</w:p>
@@ -97,7 +98,7 @@ class ContentStringTest < Sablon::TestCase
   end
 
   def test_numeric_string
-    Sablon.content(:string, 42).append_to @paragraph, @node
+    Sablon.content(:string, 42).append_to @paragraph, @node, @env
 
     output = <<-XML.strip
 <w:p><span>template</span><span>42</span></w:p><w:p>AFTER</w:p>
@@ -106,7 +107,7 @@ class ContentStringTest < Sablon::TestCase
   end
 
   def test_string_with_newlines
-    Sablon.content(:string, "a\nmultiline\n\nstring").append_to @paragraph, @node
+    Sablon.content(:string, "a\nmultiline\n\nstring").append_to @paragraph, @node, @env
 
     output = <<-XML.strip.gsub("\n", "")
 <w:p>
@@ -125,7 +126,7 @@ class ContentStringTest < Sablon::TestCase
   end
 
   def test_blank_string
-    Sablon.content(:string, "").append_to @paragraph, @node
+    Sablon.content(:string, "").append_to @paragraph, @node, @env
 
     assert_xml_equal @template_text, @document
   end
@@ -135,14 +136,14 @@ class ContentWordMLTest < Sablon::TestCase
   include ContentTestSetup
 
   def test_blank_word_ml
-    Sablon.content(:word_ml, "").append_to @paragraph, @node
+    Sablon.content(:word_ml, "").append_to @paragraph, @node, @env
 
     assert_xml_equal "<w:p>AFTER</w:p>", @document
   end
 
   def test_inserts_word_ml_into_the_document
     @word_ml = '<w:p><w:r><w:t xml:space="preserve">a </w:t></w:r></w:p>'
-    Sablon.content(:word_ml, @word_ml).append_to @paragraph, @node
+    Sablon.content(:word_ml, @word_ml).append_to @paragraph, @node, @env
 
     output = <<-XML.strip.gsub("\n", "")
 <w:p>

--- a/test/environment_test.rb
+++ b/test/environment_test.rb
@@ -16,5 +16,12 @@ class EnvironmentTest < Sablon::TestCase
     # alter context to change a single key and set a new one
     env2 = env.alter_context(a: "a", e: "new-key")
     assert_equal({ "a" => "a", "b" => { "c" => 2, "d" => 3 }, "e" => "new-key" }, env2.context)
+    # check that the old context was not modified
+    assert_equal({"a" => 1, "b" => { "c" => 2, "d" => 3 }}, env.context)
+    # check that numbering and template are the same references
+    assert env.template.equal?(env2.template), "#{env.template} != #{env2.template}"
+    assert env.numbering.equal?(env2.numbering), "#{env.numbering} != #{env2.numbering}"
+    # check that a new context reference was created
+    assert !env.context.equal?(env2.context), "#{env.context} == #{env2.context}"
   end
 end

--- a/test/html/converter_test.rb
+++ b/test/html/converter_test.rb
@@ -4,6 +4,8 @@ require "test_helper"
 class HTMLConverterTest < Sablon::TestCase
   def setup
     super
+    @env = Sablon::Environment.new(nil)
+    @numbering = @env.numbering
     @converter = Sablon::HTMLConverter.new
   end
 
@@ -15,7 +17,7 @@ class HTMLConverterTest < Sablon::TestCase
   <w:r><w:t xml:space="preserve">Lorem ipsum dolor sit amet</w:t></w:r>
 </w:p>
 DOCX
-    assert_equal normalize_wordml(expected_output), @converter.process(input)
+    assert_equal normalize_wordml(expected_output), process(input)
   end
 
   def test_convert_text_inside_p
@@ -26,7 +28,7 @@ DOCX
   <w:r><w:t xml:space="preserve">Lorem ipsum dolor sit amet</w:t></w:r>
 </w:p>
 DOCX
-    assert_equal normalize_wordml(expected_output), @converter.process(input)
+    assert_equal normalize_wordml(expected_output), process(input)
   end
 
   def test_convert_text_inside_multiple_divs
@@ -41,7 +43,7 @@ DOCX
   <w:r><w:t xml:space="preserve">dolor sit amet</w:t></w:r>
 </w:p>
 DOCX
-    assert_equal normalize_wordml(expected_output), @converter.process(input)
+    assert_equal normalize_wordml(expected_output), process(input)
   end
 
   def test_convert_newline_inside_div
@@ -54,7 +56,7 @@ DOCX
   <w:r><w:t xml:space="preserve">dolor sit amet</w:t></w:r>
 </w:p>
 DOCX
-    assert_equal normalize_wordml(expected_output), @converter.process(input)
+    assert_equal normalize_wordml(expected_output), process(input)
   end
 
   def test_convert_strong_tags_inside_div
@@ -67,7 +69,7 @@ DOCX
   <w:r><w:t xml:space="preserve"> sit amet</w:t></w:r>
 </w:p>
 DOCX
-    assert_equal normalize_wordml(expected_output), @converter.process(input)
+    assert_equal normalize_wordml(expected_output), process(input)
   end
 
   def test_convert_span_tags_inside_p
@@ -96,7 +98,7 @@ DOCX
   <w:r><w:t xml:space="preserve"> sit amet</w:t></w:r>
 </w:p>
 DOCX
-    assert_equal normalize_wordml(expected_output), @converter.process(input)
+    assert_equal normalize_wordml(expected_output), process(input)
   end
 
   def test_convert_em_tags_inside_div
@@ -109,7 +111,7 @@ DOCX
   <w:r><w:t xml:space="preserve"> sit amet</w:t></w:r>
 </w:p>
 DOCX
-    assert_equal normalize_wordml(expected_output), @converter.process(input)
+    assert_equal normalize_wordml(expected_output), process(input)
   end
 
   def test_convert_br_tags_inside_strong
@@ -128,7 +130,7 @@ DOCX
     </w:r>
 </w:p>
 DOCX
-    assert_equal normalize_wordml(expected_output), @converter.process(input)
+    assert_equal normalize_wordml(expected_output), process(input)
   end
 
   def test_convert_h1
@@ -139,7 +141,7 @@ DOCX
   <w:r><w:t xml:space="preserve">Lorem ipsum dolor</w:t></w:r>
 </w:p>
 DOCX
-    assert_equal normalize_wordml(expected_output), @converter.process(input)
+    assert_equal normalize_wordml(expected_output), process(input)
   end
 
   def test_unorderd_lists
@@ -178,9 +180,9 @@ DOCX
   <w:r><w:t xml:space="preserve">dolor</w:t></w:r>
 </w:p>
 DOCX
-    assert_equal normalize_wordml(expected_output), @converter.process(input)
+    assert_equal normalize_wordml(expected_output), process(input)
 
-    assert_equal [Sablon::Numbering::Definition.new(1001, 'ListBullet')], Sablon::Numbering.instance.definitions
+    assert_equal [Sablon::Numbering::Definition.new(1001, 'ListBullet')], @numbering.definitions
   end
 
   def test_ordered_lists
@@ -219,9 +221,9 @@ DOCX
   <w:r><w:t xml:space="preserve">dolor</w:t></w:r>
 </w:p>
 DOCX
-    assert_equal normalize_wordml(expected_output), @converter.process(input)
+    assert_equal normalize_wordml(expected_output), process(input)
 
-    assert_equal [Sablon::Numbering::Definition.new(1001, 'ListNumber')], Sablon::Numbering.instance.definitions
+    assert_equal [Sablon::Numbering::Definition.new(1001, 'ListNumber')], @numbering.definitions
   end
 
   def test_mixed_lists
@@ -260,11 +262,11 @@ DOCX
   <w:r><w:t xml:space="preserve">dolor</w:t></w:r>
 </w:p>
 DOCX
-    assert_equal normalize_wordml(expected_output), @converter.process(input)
+    assert_equal normalize_wordml(expected_output), process(input)
 
     assert_equal [Sablon::Numbering::Definition.new(1001, 'ListNumber'),
                   Sablon::Numbering::Definition.new(1002, 'ListBullet'),
-                  Sablon::Numbering::Definition.new(1003, 'ListNumber')], Sablon::Numbering.instance.definitions
+                  Sablon::Numbering::Definition.new(1003, 'ListNumber')], @numbering.definitions
   end
 
   def test_nested_unordered_lists
@@ -303,12 +305,17 @@ DOCX
   <w:r><w:t xml:space="preserve">dolor</w:t></w:r>
 </w:p>
 DOCX
-    assert_equal normalize_wordml(expected_output), @converter.process(input)
+    assert_equal normalize_wordml(expected_output), process(input)
 
-    assert_equal [Sablon::Numbering::Definition.new(1001, 'ListBullet')], Sablon::Numbering.instance.definitions
+    assert_equal [Sablon::Numbering::Definition.new(1001, 'ListBullet')], @numbering.definitions
   end
 
   private
+
+  def process(input)
+    @converter.process(input, @env)
+  end
+
   def normalize_wordml(wordml)
     wordml.gsub(/^\s+/, '').tr("\n", '')
   end
@@ -318,6 +325,7 @@ class HTMLConverterASTTest < Sablon::TestCase
   def setup
     super
     @converter = Sablon::HTMLConverter.new
+    @converter.instance_variable_set(:@numbering, Sablon::Environment.new(nil).numbering)
   end
 
   def test_div

--- a/test/html/converter_test.rb
+++ b/test/html/converter_test.rb
@@ -82,7 +82,7 @@ DOCX
   <w:r><w:t xml:space="preserve"> sit amet</w:t></w:r></w:p>
 DOCX
 
-    assert_equal normalize_wordml(expected_output), @converter.process(input)
+    assert_equal normalize_wordml(expected_output), process(input)
   end
 
   def test_convert_u_tags_inside_p

--- a/test/mail_merge_parser_test.rb
+++ b/test/mail_merge_parser_test.rb
@@ -7,6 +7,7 @@ module MailMergeParser
     include DocumentXMLHelper
     def setup
       super
+      @env = Sablon::Environment.new(nil)
       @parser = Sablon::Parser::MailMerge.new
     end
 
@@ -35,7 +36,7 @@ module MailMergeParser
     end
 
     def test_replace
-      field.replace(Sablon.content(:string, "Hello"))
+      field.replace(Sablon.content(:string, "Hello"), @env)
       xml = <<-xml.strip
 <w:p>
 <w:r w:rsidR=\"004B49F0\">
@@ -70,7 +71,7 @@ xml
     end
 
     def test_replace
-      field.replace(Sablon.content(:string, "Hello"))
+      field.replace(Sablon.content(:string, "Hello"), @env)
       xml = <<-xml.strip
 <w:p>
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,5 @@ require "sablon/test"
 class Sablon::TestCase < MiniTest::Test
   def teardown
     super
-    Sablon::Numbering.instance.reset!
   end
 end


### PR DESCRIPTION
Fixes #43 

The rebase didn't go smoothly and it was going to cause a big mess so I opted to purge the old branch and do a squashed merge instead. The diff appears rather larger but almost all of the changes are from passing the `env` variable into multiple places where Numbering was previously used, especially in the several HTML tests. 