### PR TITLE
Support arbitrary node attributes on paragraphs

### DIFF
--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -13,11 +13,7 @@ module Sablon
 
       # processes attributes defined on the node into wordML property syntax
       def process_properties
-        properties = []
-        @properties.each do |key, value|
-          properties.push transform_attr(key, value)
-        end
-        properties.join
+        @properties.map { |k, v| transform_attr(k, v) }.join
       end
 
       def transform_attr(key, value)

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -46,8 +46,9 @@ module Sablon
 
     class Paragraph < Node
       attr_accessor :style, :runs
-      def initialize(node, style, runs)
-        @style, @runs = style, runs
+      def initialize(node, runs, style)
+        @style = style
+        @runs = runs
       end
 
       PATTERN = <<-XML.gsub("\n", "")
@@ -86,8 +87,8 @@ XML
 </w:numPr>
 XML
       attr_accessor :numid, :ilvl
-      def initialize(node, definition, runs, ilvl)
-        super node, definition.style, runs
+      def initialize(node, runs, definition, ilvl)
+        super node, runs, definition.style
         @numid = definition.numid
         @ilvl = ilvl
       end

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -22,13 +22,13 @@ module Sablon
 
       def transform_attr(key, value)
         # attributes that have bracketed values get nested in tags
-        if value =~ /^\[(.+)\]$/
-          value = Regexp.last_match[1]
-          sub_attrs = value.split(';').map { |pair| pair.split(':') }
-          sub_attrs.map! { |k, v| transform_attr(k.strip, v.strip) }
+        if value.is_a? Array
+          sub_attrs = value.map do |sub_prop|
+            sub_prop.map { |k, v| transform_attr(k, v)}
+          end
           "<w:#{key}>#{sub_attrs.join}</w:#{key}>"
         else
-          '<w:%s w:val="%s" />' % [key, value]
+          format('<w:%s w:val="%s" />', key, value)
         end
       end
     end

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -17,14 +17,15 @@ module Sablon
       end
 
       def transform_attr(key, value)
-        # attributes that have bracketed values get nested in tags
+        # properties that have a list as the value get nested in tags
         if value.is_a? Array
           sub_attrs = value.map do |sub_prop|
             sub_prop.map { |k, v| transform_attr(k, v) }
           end
           "<w:#{key}>#{sub_attrs.join}</w:#{key}>"
         else
-          format('<w:%s w:val="%s" />', key, value)
+          value = format('w:val="%s" ', value) if value
+          "<w:#{key} #{value}/>"
         end
       end
     end

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -23,14 +23,14 @@ module Sablon
         @properties[key] = value
       end
 
-      def to_docx(parent_tag)
-        tag = parent_tag + 'Pr'
-        "<#{tag}>#{process}</#{tag}>" unless @properties.empty?
+      def to_docx
+        "<#{@tagname}>#{process}</#{@tagname}>" unless @properties.empty?
       end
 
       private
 
-      def initialize(properties)
+      def initialize(tagname, properties)
+        @tagname = tagname
         @properties = properties
       end
 
@@ -95,12 +95,12 @@ module Sablon
     class Paragraph < Node
       attr_accessor :runs
       def initialize(properties, runs)
-        @properties = NodeProperties.new(properties)
+        @properties = NodeProperties.new('w:pPr', properties)
         @runs = runs
       end
 
       def to_docx
-        "<w:p>#{@properties.to_docx('w:p')}#{runs.to_docx}</w:p>"
+        "<w:p>#{@properties.to_docx}#{runs.to_docx}</w:p>"
       end
 
       def accept(visitor)

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -69,8 +69,8 @@ module Sablon
 
     class Paragraph < Node
       attr_accessor :runs
-      def initialize(node, runs)
-        @attributes = node.attributes
+      def initialize(properties, runs)
+        @properties = properties
         @runs = runs
       end
 
@@ -84,7 +84,7 @@ module Sablon
       end
 
       def inspect
-        "<Paragraph{#{@attributes['pStyle']}}: #{runs.inspect}>"
+        "<Paragraph{#{@properties['pStyle']}}: #{runs.inspect}>"
       end
 
       private

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -86,9 +86,9 @@ XML
 </w:numPr>
 XML
       attr_accessor :numid, :ilvl
-      def initialize(node, style, runs, numid, ilvl)
-        super node, style, runs
-        @numid = numid
+      def initialize(node, definition, runs, ilvl)
+        super node, definition.style, runs
+        @numid = definition.numid
         @ilvl = ilvl
       end
 

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -72,7 +72,7 @@ module Sablon
       end
 
       def to_docx
-        "<w:p><w:pPr>#{ppr_docx}</w:pPr>#{runs.to_docx}</w:p>"
+        "<w:p>#{ppr_docx}#{runs.to_docx}</w:p>"
       end
 
       def accept(visitor)
@@ -87,7 +87,7 @@ module Sablon
       private
 
       def ppr_docx
-        process_properties
+        "<w:pPr>#{process_properties}</w:pPr>"
       end
     end
 

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -12,10 +12,10 @@ module Sablon
       private
 
       # processes attributes defined on the node into wordML property syntax
-      def process_attributes
+      def process_properties
         properties = []
-        @attributes.each do |key, node_attr|
-          properties.push transform_attr(key, node_attr.value)
+        @properties.each do |key, value|
+          properties.push transform_attr(key, value)
         end
         properties.join
       end
@@ -90,7 +90,7 @@ module Sablon
       private
 
       def ppr_docx
-        process_attributes
+        process_properties
       end
     end
 

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -24,7 +24,7 @@ module Sablon
         # attributes that have bracketed values get nested in tags
         if value.is_a? Array
           sub_attrs = value.map do |sub_prop|
-            sub_prop.map { |k, v| transform_attr(k, v)}
+            sub_prop.map { |k, v| transform_attr(k, v) }
           end
           "<w:#{key}>#{sub_attrs.join}</w:#{key}>"
         else

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -103,15 +103,6 @@ XML
       end
     end
 
-    class ListParagraph < Paragraph
-      attr_accessor :numid, :ilvl
-      def initialize(node, runs, numid, ilvl)
-        super node, runs
-        @numid = numid
-        @ilvl = ilvl
-      end
-    end
-
     class TextFormat
       def initialize(bold, italic, underline)
         @bold = bold

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -46,7 +46,7 @@ module Sablon
 
     class Paragraph < Node
       attr_accessor :style, :runs
-      def initialize(style, runs)
+      def initialize(node, style, runs)
         @style, @runs = style, runs
       end
 
@@ -86,8 +86,8 @@ XML
 </w:numPr>
 XML
       attr_accessor :numid, :ilvl
-      def initialize(style, runs, numid, ilvl)
-        super style, runs
+      def initialize(node, style, runs, numid, ilvl)
+        super node, style, runs
         @numid = numid
         @ilvl = ilvl
       end

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -49,8 +49,8 @@ module Sablon
           end
           "<w:#{key}>#{sub_attrs.join}</w:#{key}>"
         elsif value.is_a? Hash
-          props = value.map { |k, v| format('w:%s="%s"', k, v) }
-          "<w:#{key} #{props.join(' ')} />"
+          props = value.map { |k, v| format('w:%s="%s"', k, v) if v }
+          "<w:#{key} #{props.compact.join(' ')} />"
         else
           value = format('w:val="%s" ', value) if value
           "<w:#{key} #{value}/>"

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -46,8 +46,8 @@ module Sablon
 
     class Paragraph < Node
       attr_accessor :style, :runs
-      def initialize(node, runs, style)
-        @style = style
+      def initialize(node, runs)
+        @style = node['class']
         @runs = runs
       end
 
@@ -87,9 +87,9 @@ XML
 </w:numPr>
 XML
       attr_accessor :numid, :ilvl
-      def initialize(node, runs, definition, ilvl)
-        super node, runs, definition.style
-        @numid = definition.numid
+      def initialize(node, runs, numid, ilvl)
+        super node, runs
+        @numid = numid
         @ilvl = ilvl
       end
 

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -74,17 +74,8 @@ module Sablon
         @runs = runs
       end
 
-      PATTERN = <<-XML.gsub("\n", "")
-<w:p>
-<w:pPr>
-%s
-</w:pPr>
-%s
-</w:p>
-XML
-
       def to_docx
-        PATTERN % [ppr_docx, runs.to_docx]
+        "<w:p><w:pPr>#{ppr_docx}</w:pPr>#{runs.to_docx}</w:p>"
       end
 
       def accept(visitor)

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -11,6 +11,15 @@ module Sablon
     end
 
     class NodeProperties
+      def self.paragraph(properties)
+        NodeProperties.new('w:pPr', properties)
+      end
+
+      def initialize(tagname, properties)
+        @tagname = tagname
+        @properties = properties
+      end
+
       def inspect
         @properties.map { |k, v| v ? "#{k}=#{v}" : k }.join(';')
       end
@@ -28,11 +37,6 @@ module Sablon
       end
 
       private
-
-      def initialize(tagname, properties)
-        @tagname = tagname
-        @properties = properties
-      end
 
       # processes attributes defined on the node into wordML property syntax
       def process
@@ -95,7 +99,7 @@ module Sablon
     class Paragraph < Node
       attr_accessor :runs
       def initialize(properties, runs)
-        @properties = NodeProperties.new('w:pPr', properties)
+        @properties = NodeProperties.paragraph(properties)
         @runs = runs
       end
 

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -11,7 +11,7 @@ module Sablon
 
       private
 
-      # processes attributs defined on the node into wordML property syntax
+      # processes attributes defined on the node into wordML property syntax
       def process_attributes
         properties = []
         @attributes.each do |key, node_attr|
@@ -21,7 +21,7 @@ module Sablon
       end
 
       def transform_attr(key, value)
-        # atrributes that have quoted values get nested in tags
+        # attributes that have bracketed values get nested in tags
         if value =~ /^\[(.+)\]$/
           value = Regexp.last_match[1]
           sub_attrs = value.split(';').map { |pair| pair.split(':') }

--- a/lib/sablon/html/converter.rb
+++ b/lib/sablon/html/converter.rb
@@ -103,30 +103,32 @@ module Sablon
         raise ArgumentError, "Don't know how to handle node: #{node.inspect}"
       end
       #
-      node['pStyle'] = styles[tag] + num
+      properties = {}
+      properties['pStyle'] = styles[tag] + num
+      properties
     end
 
     def ast_next_paragraph
       node = @builder.next
       return if node.text?
 
-      prepare_paragraph(node)
+      properties = prepare_paragraph(node)
 
       # handle special cases
       if node.name =~ /ul|ol/
         @builder.new_layer ilvl: true
         unless @builder.nested?
-          @definition = @numbering.register(node['pStyle'])
+          @definition = @numbering.register(properties['pStyle'])
         end
         @builder.push_all(node.children)
         return
       elsif node.name == 'li'
-        node['numPr'] = "[ilvl: #{@builder.ilvl}; numId: #{@definition.numid};]"
+        properties['numPr'] = "[ilvl: #{@builder.ilvl}; numId: #{@definition.numid};]"
       end
 
       # create word_ml node
       @builder.new_layer
-      @builder.emit Paragraph.new(node, ast_text(node.children))
+      @builder.emit Paragraph.new(node, properties, ast_text(node.children))
     end
 
     def ast_text(nodes, format: TextFormat.default)

--- a/lib/sablon/html/converter.rb
+++ b/lib/sablon/html/converter.rb
@@ -120,7 +120,7 @@ module Sablon
         @builder.push_all(node.children)
         return
       elsif node.name == 'li'
-        #node['numPr'] = "numId: #{@definition.numid}; ilvl: #{@builder.ilvl};"
+        node['numPr'] = "[ilvl: #{@builder.ilvl}; numId: #{@definition.numid};]"
         @builder.new_layer
         @builder.emit ListParagraph.new(node, ast_text(node.children), @definition.numid, @builder.ilvl)
       elsif node.name =~ /div|p|h/

--- a/lib/sablon/html/converter.rb
+++ b/lib/sablon/html/converter.rb
@@ -113,7 +113,7 @@ module Sablon
       prepare_node(node)
       if node.name =~ /div|p|h/
         @builder.new_layer
-        @builder.emit Paragraph.new(node, ast_text(node.children), node['class'])
+        @builder.emit Paragraph.new(node, ast_text(node.children))
       elsif node.name =~ /ul|ol/
         @builder.new_layer ilvl: true
         unless @builder.nested?
@@ -122,7 +122,7 @@ module Sablon
         @builder.push_all(node.children)
       elsif node.name == 'li'
         @builder.new_layer
-        @builder.emit ListParagraph.new(node, ast_text(node.children),  @definition, @builder.ilvl)
+        @builder.emit ListParagraph.new(node, ast_text(node.children), @definition.numid, @builder.ilvl)
       end
     end
 

--- a/lib/sablon/html/converter.rb
+++ b/lib/sablon/html/converter.rb
@@ -95,13 +95,13 @@ module Sablon
       node = @builder.next
       if node.name == 'div'
         @builder.new_layer
-        @builder.emit Paragraph.new(node, 'Normal', ast_text(node.children))
+        @builder.emit Paragraph.new(node, ast_text(node.children), 'Normal')
       elsif node.name == 'p'
         @builder.new_layer
-        @builder.emit Paragraph.new(node, 'Paragraph', ast_text(node.children))
+        @builder.emit Paragraph.new(node, ast_text(node.children), 'Paragraph')
       elsif node.name =~ /h(\d+)/
         @builder.new_layer
-        @builder.emit Paragraph.new(node, "Heading#{$1}", ast_text(node.children))
+        @builder.emit Paragraph.new(node, ast_text(node.children), "Heading#{$1}")
       elsif node.name == 'ul'
         @builder.new_layer ilvl: true
         unless @builder.nested?
@@ -116,7 +116,7 @@ module Sablon
         @builder.push_all(node.children)
       elsif node.name == 'li'
         @builder.new_layer
-        @builder.emit ListParagraph.new(node, @definition, ast_text(node.children), @builder.ilvl)
+        @builder.emit ListParagraph.new(node, ast_text(node.children),  @definition, @builder.ilvl)
       elsif node.text?
         # SKIP?
       else

--- a/lib/sablon/html/converter.rb
+++ b/lib/sablon/html/converter.rb
@@ -123,7 +123,9 @@ module Sablon
         @builder.push_all(node.children)
         return
       elsif node.name == 'li'
-        properties['numPr'] = "[ilvl: #{@builder.ilvl}; numId: #{@definition.numid};]"
+        properties['numPr'] = [
+          { 'ilvl' => @builder.ilvl }, { 'numId' => @definition.numid }
+        ]
       end
 
       # create word_ml node

--- a/lib/sablon/html/converter.rb
+++ b/lib/sablon/html/converter.rb
@@ -92,8 +92,6 @@ module Sablon
 
     # Adds the appropriate style class to the node
     def prepare_node(node)
-      return if node.text?
-
       # set default styles based on node name
       styles = { 'div' => 'Normal', 'p' => 'Paragraph', 'h' => 'Heading',
                  'ul' => 'ListBullet', 'ol' => 'ListNumber' }
@@ -110,8 +108,11 @@ module Sablon
 
     def ast_next_paragraph
       node = @builder.next
+      return if node.text?
+
       prepare_node(node)
 
+      # handle special cases
       if node.name =~ /ul|ol/
         @builder.new_layer ilvl: true
         unless @builder.nested?
@@ -121,12 +122,11 @@ module Sablon
         return
       elsif node.name == 'li'
         node['numPr'] = "[ilvl: #{@builder.ilvl}; numId: #{@definition.numid};]"
-        @builder.new_layer
-        @builder.emit ListParagraph.new(node, ast_text(node.children), @definition.numid, @builder.ilvl)
-      elsif node.name =~ /div|p|h/
-        @builder.new_layer
-        @builder.emit Paragraph.new(node, ast_text(node.children))
       end
+
+      # create word_ml node
+      @builder.new_layer
+      @builder.emit Paragraph.new(node, ast_text(node.children))
     end
 
     def ast_text(nodes, format: TextFormat.default)

--- a/lib/sablon/html/converter.rb
+++ b/lib/sablon/html/converter.rb
@@ -120,12 +120,12 @@ module Sablon
         @builder.push_all(node.children)
         return
       elsif node.name == 'li'
-        node['numPr'] = "numId: #{@definition.numid}; ilvl: #{@builder.ilvl};"
+        #node['numPr'] = "numId: #{@definition.numid}; ilvl: #{@builder.ilvl};"
         @builder.new_layer
         @builder.emit ListParagraph.new(node, ast_text(node.children), @definition.numid, @builder.ilvl)
       elsif node.name =~ /div|p|h/
-          @builder.new_layer
-          @builder.emit Paragraph.new(node, ast_text(node.children))
+        @builder.new_layer
+        @builder.emit Paragraph.new(node, ast_text(node.children))
       end
     end
 

--- a/lib/sablon/html/converter.rb
+++ b/lib/sablon/html/converter.rb
@@ -128,7 +128,7 @@ module Sablon
 
       # create word_ml node
       @builder.new_layer
-      @builder.emit Paragraph.new(node, properties, ast_text(node.children))
+      @builder.emit Paragraph.new(properties, ast_text(node.children))
     end
 
     def ast_text(nodes, format: TextFormat.default)

--- a/lib/sablon/html/converter.rb
+++ b/lib/sablon/html/converter.rb
@@ -89,6 +89,7 @@ module Sablon
 
     def initialize
       @numbering = nil
+    end
 
     # Adds the appropriate style class to the node
     def prepare_paragraph(node)

--- a/lib/sablon/html/converter.rb
+++ b/lib/sablon/html/converter.rb
@@ -105,24 +105,27 @@ module Sablon
         raise ArgumentError, "Don't know how to handle node: #{node.inspect}"
       end
       #
-      node['class'] = styles[tag] + num
+      node['pStyle'] = styles[tag] + num
     end
 
     def ast_next_paragraph
       node = @builder.next
       prepare_node(node)
-      if node.name =~ /div|p|h/
-        @builder.new_layer
-        @builder.emit Paragraph.new(node, ast_text(node.children))
-      elsif node.name =~ /ul|ol/
+
+      if node.name =~ /ul|ol/
         @builder.new_layer ilvl: true
         unless @builder.nested?
-          @definition = @numbering.register(node['class'])
+          @definition = @numbering.register(node['pStyle'])
         end
         @builder.push_all(node.children)
+        return
       elsif node.name == 'li'
+        node['numPr'] = "numId: #{@definition.numid}; ilvl: #{@builder.ilvl};"
         @builder.new_layer
         @builder.emit ListParagraph.new(node, ast_text(node.children), @definition.numid, @builder.ilvl)
+      elsif node.name =~ /div|p|h/
+          @builder.new_layer
+          @builder.emit Paragraph.new(node, ast_text(node.children))
       end
     end
 

--- a/lib/sablon/html/converter.rb
+++ b/lib/sablon/html/converter.rb
@@ -91,7 +91,7 @@ module Sablon
       @numbering = nil
 
     # Adds the appropriate style class to the node
-    def prepare_node(node)
+    def prepare_paragraph(node)
       # set default styles based on node name
       styles = { 'div' => 'Normal', 'p' => 'Paragraph', 'h' => 'Heading',
                  'ul' => 'ListBullet', 'ol' => 'ListNumber' }
@@ -110,7 +110,7 @@ module Sablon
       node = @builder.next
       return if node.text?
 
-      prepare_node(node)
+      prepare_paragraph(node)
 
       # handle special cases
       if node.name =~ /ul|ol/

--- a/lib/sablon/html/converter.rb
+++ b/lib/sablon/html/converter.rb
@@ -116,7 +116,7 @@ module Sablon
         @builder.push_all(node.children)
       elsif node.name == 'li'
         @builder.new_layer
-        @builder.emit ListParagraph.new(node, @definition.style, ast_text(node.children), @definition.numid, @builder.ilvl)
+        @builder.emit ListParagraph.new(node, @definition, ast_text(node.children), @builder.ilvl)
       elsif node.text?
         # SKIP?
       else

--- a/lib/sablon/html/converter.rb
+++ b/lib/sablon/html/converter.rb
@@ -95,13 +95,13 @@ module Sablon
       node = @builder.next
       if node.name == 'div'
         @builder.new_layer
-        @builder.emit Paragraph.new('Normal', ast_text(node.children))
+        @builder.emit Paragraph.new(node, 'Normal', ast_text(node.children))
       elsif node.name == 'p'
         @builder.new_layer
-        @builder.emit Paragraph.new('Paragraph', ast_text(node.children))
+        @builder.emit Paragraph.new(node, 'Paragraph', ast_text(node.children))
       elsif node.name =~ /h(\d+)/
         @builder.new_layer
-        @builder.emit Paragraph.new("Heading#{$1}", ast_text(node.children))
+        @builder.emit Paragraph.new(node, "Heading#{$1}", ast_text(node.children))
       elsif node.name == 'ul'
         @builder.new_layer ilvl: true
         unless @builder.nested?
@@ -116,7 +116,7 @@ module Sablon
         @builder.push_all(node.children)
       elsif node.name == 'li'
         @builder.new_layer
-        @builder.emit ListParagraph.new(@definition.style, ast_text(node.children), @definition.numid, @builder.ilvl)
+        @builder.emit ListParagraph.new(node, @definition.style, ast_text(node.children), @definition.numid, @builder.ilvl)
       elsif node.text?
         # SKIP?
       else

--- a/test/html/converter_test.rb
+++ b/test/html/converter_test.rb
@@ -408,40 +408,30 @@ class HTMLConverterASTTest < Sablon::TestCase
 
   def test_num_id
     ast = @converter.processed_ast('<ol><li>Some</li><li>Lorem</li></ol><ul><li>ipsum</li></ul><ol><li>dolor</li><li>sit</li></ol>')
-    assert_equal %w[1001 1001 1002 1003 1003], get_numid_from_ast(ast)
+    assert_equal [1001, 1001, 1002, 1003, 1003], get_numpr_prop_from_ast(ast, 'numId')
   end
 
   def test_nested_lists_have_the_same_numid
     ast = @converter.processed_ast('<ul><li>Lorem<ul><li>ipsum<ul><li>dolor</li></ul></li></ul></li></ul>')
-    assert_equal %w[1001 1001 1001], get_numid_from_ast(ast)
+    assert_equal [1001, 1001, 1001], get_numpr_prop_from_ast(ast, 'numId')
   end
 
   def test_keep_nested_list_order
     input = '<ul><li>1<ul><li>1.1<ul><li>1.1.1</li></ul></li><li>1.2</li></ul></li><li>2<ul><li>1.3<ul><li>1.3.1</li></ul></li></ul></li></ul>'
     ast = @converter.processed_ast(input)
-    assert_equal %w[1001], get_numid_from_ast(ast).uniq
-    assert_equal %w[0 1 2 1 0 1 2], get_ilvl_from_ast(ast)
+    assert_equal [1001], get_numpr_prop_from_ast(ast, 'numId').uniq
+    assert_equal [0, 1, 2, 1, 0, 1, 2], get_numpr_prop_from_ast(ast, 'ilvl')
   end
 
   private
 
   # returns the numid attribute from paragraphs
-  def get_numid_from_ast(ast)
-    numids = []
+  def get_numpr_prop_from_ast(ast, key)
+    values = []
     ast.grep(Sablon::HTMLConverter::Paragraph).each do |para|
       numpr = para.instance_variable_get('@properties')['numPr']
-      numids.push(numpr.match(/numId: (\d+);/)[1])
+      numpr.each { |val| values.push(val[key]) if val[key] }
     end
-    numids
-  end
-
-  # returns the ilvl attribute from paragraphs
-  def get_ilvl_from_ast(ast)
-    numids = []
-    ast.grep(Sablon::HTMLConverter::Paragraph).each do |para|
-      numpr = para.instance_variable_get('@properties')['numPr']
-      numids.push(numpr.match(/ilvl: (\d+);/)[1])
-    end
-    numids
+    values
   end
 end

--- a/test/html/converter_test.rb
+++ b/test/html/converter_test.rb
@@ -330,29 +330,29 @@ class HTMLConverterASTTest < Sablon::TestCase
 
   def test_node_properties_converison
     # test empty properties
-    props = Sablon::HTMLConverter::NodeProperties.new({})
+    props = Sablon::HTMLConverter::NodeProperties.new('w:pPr', {})
     assert props.inspect == ''
-    assert props.to_docx('w:p').nil?
+    assert props.to_docx.nil?
     # test simple properties
     props = { 'pStyle' => 'Paragraph' }
-    props = Sablon::HTMLConverter::NodeProperties.new(props)
+    props = Sablon::HTMLConverter::NodeProperties.new('w:pPr', props)
     assert props.inspect == 'pStyle=Paragraph'
-    assert props.to_docx('w:p') == '<w:pPr><w:pStyle w:val="Paragraph" /></w:pPr>'
+    assert props.to_docx == '<w:pPr><w:pStyle w:val="Paragraph" /></w:pPr>'
     # test property with nil value
     props = { 'b' => nil }
-    props = Sablon::HTMLConverter::NodeProperties.new(props)
+    props = Sablon::HTMLConverter::NodeProperties.new('w:rPr', props)
     assert props.inspect == 'b'
-    assert props.to_docx('w:r') == '<w:rPr><w:b /></w:rPr>'
+    assert props.to_docx == '<w:rPr><w:b /></w:rPr>'
     # test property with hash value
     props = { 'shd' => { color: 'clear', fill: '123456', test: nil } }
-    props = Sablon::HTMLConverter::NodeProperties.new(props)
+    props = Sablon::HTMLConverter::NodeProperties.new('w:rPr', props)
     assert props.inspect == 'shd={:color=>"clear", :fill=>"123456", :test=>nil}'
-    assert props.to_docx('w:r') == '<w:rPr><w:shd w:color="clear" w:fill="123456" /></w:rPr>'
+    assert props.to_docx == '<w:rPr><w:shd w:color="clear" w:fill="123456" /></w:rPr>'
     # test property with array value
     props = { 'numPr' => [{ 'ilvl' => 1 }, { 'numId' => 34 }] }
-    props = Sablon::HTMLConverter::NodeProperties.new(props)
+    props = Sablon::HTMLConverter::NodeProperties.new('w:pPr', props)
     assert props.inspect == 'numPr=[{"ilvl"=>1}, {"numId"=>34}]'
-    assert props.to_docx('w:p') == '<w:pPr><w:numPr><w:ilvl w:val="1" /><w:numId w:val="34" /></w:numPr></w:pPr>'
+    assert props.to_docx == '<w:pPr><w:numPr><w:ilvl w:val="1" /><w:numId w:val="34" /></w:numPr></w:pPr>'
     # test complex nested properties
     props = {
       'top1' => 'val1',
@@ -380,8 +380,8 @@ class HTMLConverterASTTest < Sablon::TestCase
         <w:top3 w:key1="1" w:key2="2" w:key4="true" />
       </w:pPr>
     DOCX
-    props = Sablon::HTMLConverter::NodeProperties.new(props)
-    assert props.to_docx('w:p') == output
+    props = Sablon::HTMLConverter::NodeProperties.new('w:pPr', props)
+    assert props.to_docx == output
   end
 
   def test_div

--- a/test/html/converter_test.rb
+++ b/test/html/converter_test.rb
@@ -429,7 +429,7 @@ class HTMLConverterASTTest < Sablon::TestCase
   def get_numid_from_ast(ast)
     numids = []
     ast.grep(Sablon::HTMLConverter::Paragraph).each do |para|
-      numpr = para.instance_variable_get('@attributes')['numPr'].value
+      numpr = para.instance_variable_get('@properties')['numPr']
       numids.push(numpr.match(/numId: (\d+);/)[1])
     end
     numids
@@ -439,7 +439,7 @@ class HTMLConverterASTTest < Sablon::TestCase
   def get_ilvl_from_ast(ast)
     numids = []
     ast.grep(Sablon::HTMLConverter::Paragraph).each do |para|
-      numpr = para.instance_variable_get('@attributes')['numPr'].value
+      numpr = para.instance_variable_get('@properties')['numPr']
       numids.push(numpr.match(/ilvl: (\d+);/)[1])
     end
     numids

--- a/test/html/converter_test.rb
+++ b/test/html/converter_test.rb
@@ -394,6 +394,13 @@ class HTMLConverterASTTest < Sablon::TestCase
     assert props.to_docx == output
   end
 
+  def test_node_properties_paragraph_factory
+    props = { 'pStyle' => 'Paragraph' }
+    props = Sablon::HTMLConverter::NodeProperties.paragraph(props)
+    assert props.inspect == 'pStyle=Paragraph'
+    assert props.to_docx == '<w:pPr><w:pStyle w:val="Paragraph" /></w:pPr>'
+  end
+
   def test_div
     input = '<div>Lorem ipsum dolor sit amet</div>'
     ast = @converter.processed_ast(input)

--- a/test/html/converter_test.rb
+++ b/test/html/converter_test.rb
@@ -328,32 +328,42 @@ class HTMLConverterASTTest < Sablon::TestCase
     @converter.instance_variable_set(:@numbering, Sablon::Environment.new(nil).numbering)
   end
 
-  def test_node_properties_converison
+  def test_empty_node_properties_converison
     # test empty properties
     props = Sablon::HTMLConverter::NodeProperties.new('w:pPr', {})
     assert props.inspect == ''
     assert props.to_docx.nil?
-    # test simple properties
+  end
+
+  def test_simple_node_property_converison
     props = { 'pStyle' => 'Paragraph' }
     props = Sablon::HTMLConverter::NodeProperties.new('w:pPr', props)
     assert props.inspect == 'pStyle=Paragraph'
     assert props.to_docx == '<w:pPr><w:pStyle w:val="Paragraph" /></w:pPr>'
-    # test property with nil value
+  end
+
+  def test_node_property_with_nil_value_converison
     props = { 'b' => nil }
     props = Sablon::HTMLConverter::NodeProperties.new('w:rPr', props)
     assert props.inspect == 'b'
     assert props.to_docx == '<w:rPr><w:b /></w:rPr>'
-    # test property with hash value
+  end
+
+  def test_node_property_with_hash_value_converison
     props = { 'shd' => { color: 'clear', fill: '123456', test: nil } }
     props = Sablon::HTMLConverter::NodeProperties.new('w:rPr', props)
     assert props.inspect == 'shd={:color=>"clear", :fill=>"123456", :test=>nil}'
     assert props.to_docx == '<w:rPr><w:shd w:color="clear" w:fill="123456" /></w:rPr>'
-    # test property with array value
+  end
+
+  def test_node_property_with_array_value_converison
     props = { 'numPr' => [{ 'ilvl' => 1 }, { 'numId' => 34 }] }
     props = Sablon::HTMLConverter::NodeProperties.new('w:pPr', props)
     assert props.inspect == 'numPr=[{"ilvl"=>1}, {"numId"=>34}]'
     assert props.to_docx == '<w:pPr><w:numPr><w:ilvl w:val="1" /><w:numId w:val="34" /></w:numPr></w:pPr>'
-    # test complex nested properties
+  end
+
+  def test_complex_node_properties_conversion
     props = {
       'top1' => 'val1',
       'top2' => [

--- a/test/html/converter_test.rb
+++ b/test/html/converter_test.rb
@@ -328,6 +328,62 @@ class HTMLConverterASTTest < Sablon::TestCase
     @converter.instance_variable_set(:@numbering, Sablon::Environment.new(nil).numbering)
   end
 
+  def test_node_properties_converison
+    # test empty properties
+    props = Sablon::HTMLConverter::NodeProperties.new({})
+    assert props.inspect == ''
+    assert props.to_docx('w:p').nil?
+    # test simple properties
+    props = { 'pStyle' => 'Paragraph' }
+    props = Sablon::HTMLConverter::NodeProperties.new(props)
+    assert props.inspect == 'pStyle=Paragraph'
+    assert props.to_docx('w:p') == '<w:pPr><w:pStyle w:val="Paragraph" /></w:pPr>'
+    # test property with nil value
+    props = { 'b' => nil }
+    props = Sablon::HTMLConverter::NodeProperties.new(props)
+    assert props.inspect == 'b'
+    assert props.to_docx('w:r') == '<w:rPr><w:b /></w:rPr>'
+    # test property with hash value
+    props = { 'shd' => { color: 'clear', fill: '123456', test: nil } }
+    props = Sablon::HTMLConverter::NodeProperties.new(props)
+    assert props.inspect == 'shd={:color=>"clear", :fill=>"123456", :test=>nil}'
+    assert props.to_docx('w:r') == '<w:rPr><w:shd w:color="clear" w:fill="123456" /></w:rPr>'
+    # test property with array value
+    props = { 'numPr' => [{ 'ilvl' => 1 }, { 'numId' => 34 }] }
+    props = Sablon::HTMLConverter::NodeProperties.new(props)
+    assert props.inspect == 'numPr=[{"ilvl"=>1}, {"numId"=>34}]'
+    assert props.to_docx('w:p') == '<w:pPr><w:numPr><w:ilvl w:val="1" /><w:numId w:val="34" /></w:numPr></w:pPr>'
+    # test complex nested properties
+    props = {
+      'top1' => 'val1',
+      'top2' => [
+        { 'mid0' => nil },
+        { 'mid1' => [
+          { 'bottom1' => { key1: 'abc' } },
+          { 'bottom2' => 'xyz' }
+        ] },
+        { 'mid2' => 'val2' }
+      ],
+      'top3' => { key1: 1, key2: '2', key3: nil, key4: true, key5: false }
+    }
+    output = <<-DOCX.gsub(/^\s*/, '').delete("\n")
+      <w:pPr>
+        <w:top1 w:val="val1" />
+        <w:top2>
+          <w:mid0 />
+          <w:mid1>
+            <w:bottom1 w:key1="abc" />
+            <w:bottom2 w:val="xyz" />
+          </w:mid1>
+          <w:mid2 w:val="val2" />
+        </w:top2>
+        <w:top3 w:key1="1" w:key2="2" w:key4="true" />
+      </w:pPr>
+    DOCX
+    props = Sablon::HTMLConverter::NodeProperties.new(props)
+    assert props.to_docx('w:p') == output
+  end
+
   def test_div
     input = '<div>Lorem ipsum dolor sit amet</div>'
     ast = @converter.processed_ast(input)

--- a/test/html/converter_test.rb
+++ b/test/html/converter_test.rb
@@ -408,19 +408,40 @@ class HTMLConverterASTTest < Sablon::TestCase
 
   def test_num_id
     ast = @converter.processed_ast('<ol><li>Some</li><li>Lorem</li></ol><ul><li>ipsum</li></ul><ol><li>dolor</li><li>sit</li></ol>')
-    assert_equal [1001, 1001, 1002, 1003, 1003], ast.grep(Sablon::HTMLConverter::ListParagraph).map(&:numid)
+    assert_equal %w[1001 1001 1002 1003 1003], get_numid_from_ast(ast)
   end
 
   def test_nested_lists_have_the_same_numid
     ast = @converter.processed_ast('<ul><li>Lorem<ul><li>ipsum<ul><li>dolor</li></ul></li></ul></li></ul>')
-    assert_equal [1001, 1001, 1001], ast.grep(Sablon::HTMLConverter::ListParagraph).map(&:numid)
+    assert_equal %w[1001 1001 1001], get_numid_from_ast(ast)
   end
 
   def test_keep_nested_list_order
     input = '<ul><li>1<ul><li>1.1<ul><li>1.1.1</li></ul></li><li>1.2</li></ul></li><li>2<ul><li>1.3<ul><li>1.3.1</li></ul></li></ul></li></ul>'
     ast = @converter.processed_ast(input)
-    list_p = ast.grep(Sablon::HTMLConverter::ListParagraph)
-    assert_equal [1001], list_p.map(&:numid).uniq
-    assert_equal [0, 1, 2, 1, 0, 1, 2], list_p.map(&:ilvl)
+    assert_equal %w[1001], get_numid_from_ast(ast).uniq
+    assert_equal %w[0 1 2 1 0 1 2], get_ilvl_from_ast(ast)
+  end
+
+  private
+
+  # returns the numid attribute from paragraphs
+  def get_numid_from_ast(ast)
+    numids = []
+    ast.grep(Sablon::HTMLConverter::Paragraph).each do |para|
+      numpr = para.instance_variable_get('@attributes')['numPr'].value
+      numids.push(numpr.match(/numId: (\d+);/)[1])
+    end
+    numids
+  end
+
+  # returns the ilvl attribute from paragraphs
+  def get_ilvl_from_ast(ast)
+    numids = []
+    ast.grep(Sablon::HTMLConverter::Paragraph).each do |para|
+      numpr = para.instance_variable_get('@attributes')['numPr'].value
+      numids.push(numpr.match(/ilvl: (\d+);/)[1])
+    end
+    numids
   end
 end


### PR DESCRIPTION
<s>This lays the ground work for support of the style attribute by allowing any attributes set on an HTML node to be passed onto the WordML paragraph node. It also removes the need of the `ListParagraph` node subclass since we can now just pass the `numPr` attributes directly through.

Currently all attributes get shoved into the following template `<w:%s w:val="%s" />`, this will likely change when I implement styles because of tags like `</w:b>`. Nested attributes can be achieved by storing the value of your attribute in square brackets, i.e. `"[ilvl: #{@builder.ilvl}; numId: #{@definition.numid};]"`. 

I didn't intend for this to be advertised as a public API since it is primarily meant to serve our own internal needs but I didn't prevent it by white listing accepted attributes (or clearing them and setting our own). I figure there might be some good use cases out there that i don't know about.
</s>
Implementing the `style=` tag will make a pretty large diff in of itself just from the required boiler plate and creation of tests so I decided to split the PRs up again. 

(This PR conflicts with #49 in two files so which ever one you merge first, I'll fix the other)