### PR TITLE
Ensure missing loop variables do not raise error

### DIFF
--- a/lib/sablon/operations.rb
+++ b/lib/sablon/operations.rb
@@ -14,6 +14,7 @@ module Sablon
     class Loop < Struct.new(:list_expr, :iterator_name, :block)
       def evaluate(env)
         value = list_expr.evaluate(env.context)
+        value = [] if value.nil?
         value = value.to_ary if value.respond_to?(:to_ary)
         raise ContextError, "The expression #{list_expr.inspect} should evaluate to an enumerable but was: #{value.inspect}" unless value.is_a?(Enumerable)
 
@@ -21,7 +22,7 @@ module Sablon
           iter_env = env.alter_context(iterator_name => item)
           block.process(iter_env)
         end
-        block.replace(content.reverse)
+        block.replace(content.reverse) if block
       end
     end
 

--- a/test/expression_test.rb
+++ b/test/expression_test.rb
@@ -58,4 +58,14 @@ class LookupOrMethodCallTest < Sablon::TestCase
     assert_equal nil, expr.evaluate("user" => user)
     assert_equal nil, expr.evaluate({})
   end
+
+  def test_missing_collection_receiver
+    env = Sablon::Environment.new(nil, {})
+
+    expr = Sablon::Statement::Loop.new(Sablon::Expression.parse("db.users:each(user)"))
+    assert_equal nil, expr.evaluate(env)
+
+    expr = Sablon::Statement::Loop.new(Sablon::Expression.parse("db.users:endEach"))
+    assert_equal nil, expr.evaluate(env)
+  end
 end

--- a/test/processor/document_test.rb
+++ b/test/processor/document_test.rb
@@ -334,11 +334,11 @@ class ProcessorDocumentTest < Sablon::TestCase
     end
   end
 
-  def test_loop_with_missing_variable_raises_error
+  def test_loop_with_non_enumerable_value
     e = assert_raises Sablon::ContextError do
-      process(snippet("paragraph_loop"), {})
+      process(snippet("paragraph_loop"), { "technologies" => "string" })
     end
-    assert_equal "The expression «technologies» should evaluate to an enumerable but was: nil", e.message
+    assert_equal "The expression «technologies» should evaluate to an enumerable but was: \"string\"", e.message
   end
 
   def test_loop_with_missing_end_raises_error


### PR DESCRIPTION
When I'm using somewhere in templates collections like this:
```
users:each(user)
```
And according to [this assertion](https://github.com/senny/sablon/blob/master/test/processor/document_test.rb#L341), Sablon raises the error below when I don't provide the collection:
```
The expression «users» should evaluate to an enumerable but was: nil
```
The problem is that sometimes I cannot provide loop expressions within the template, which is useful for one to make previews without containing all the needed data. Such cases would be better to "skip" this error, not raising the error instead. Pretty much like we do [here](https://github.com/senny/sablon/blob/master/test/expression_test.rb#L55).