### PR TITLE
Fixes comment block's start field regex

### DIFF
--- a/lib/sablon/processor/document.rb
+++ b/lib/sablon/processor/document.rb
@@ -171,7 +171,7 @@ module Sablon
           when /([^ ]+):if/
             block = consume_block("#{$1}:endIf")
             Statement::Condition.new(Expression.parse($1), block)
-          when /comment/
+          when /^comment$/
             block = consume_block("endComment")
             Statement::Comment.new(block)
           end

--- a/test/fixtures/xml/comment_block_and_comment_as_key.xml
+++ b/test/fixtures/xml/comment_block_and_comment_as_key.xml
@@ -1,0 +1,31 @@
+<w:r><w:t xml:space="preserve">Before </w:t></w:r>
+<w:p>
+<w:fldSimple w:instr=" MERGEFIELD comment \* MERGEFORMAT ">
+  <w:r>
+    <w:rPr><w:noProof/></w:rPr>
+    <w:t>«comment»</w:t>
+  </w:r>
+</w:fldSimple>
+</w:p>
+<w:p>
+<w:r>
+  <w:t>Inside Comment! </w:t>
+</w:r>
+</w:p>
+<w:p>
+<w:fldSimple w:instr=" MERGEFIELD endComment \* MERGEFORMAT ">
+  <w:r>
+    <w:rPr><w:noProof/></w:rPr>
+    <w:t>«endComment»</w:t>
+  </w:r>
+</w:fldSimple>
+</w:p>
+<w:p>
+<w:fldSimple w:instr=" MERGEFIELD =comment \* MERGEFORMAT ">
+  <w:r w:rsidR="004B49F0">
+    <w:rPr><w:noProof/></w:rPr>
+    <w:t>«=comment»</w:t>
+  </w:r>
+</w:fldSimple>
+</w:p>
+<w:r><w:t xml:space="preserve">After </w:t></w:r>

--- a/test/processor/document_test.rb
+++ b/test/processor/document_test.rb
@@ -440,6 +440,21 @@ class ProcessorDocumentTest < Sablon::TestCase
     assert_equal "Before After", text(result)
   end
 
+  def test_comment_block_and_comment_as_key
+    result = process(snippet("comment_block_and_comment_as_key"), {comment: 'Contents of comment key'})
+
+    assert_xml_equal <<-document, result
+    <w:r><w:t xml:space="preserve">Before </w:t></w:r>
+    <w:r><w:t xml:space="preserve">After </w:t></w:r>
+    <w:p>           
+      <w:r w:rsidR="004B49F0">
+        <w:rPr><w:noProof/></w:rPr>
+        <w:t>Contents of comment key</w:t>
+      </w:r>
+    </w:p>
+    document
+  end
+
   private
 
   def process(document, context)


### PR DESCRIPTION
Fixes #56

I have also added test to ensure, documents having both comment block and comment as key works fine.