### PR TITLE
Support for equality operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,22 @@ For more complex conditionals you can use a predicate like so:
 «body:endIf»
 ```
 
+It's also possible to use equality operators for conditionals:
+
+```
+«technology:if(=='Ruby')»
+    ... arbitrary document markup ...
+«technologies:endIf»
+```
+
+```
+«intValue:if(!=42)»
+    ... arbitrary document markup ...
+«intValue:endIf»
+```
+
+Strings need to be enclosed in single quotes, e.g. ```'String'```. The value after the operator will be compared against the value of the context variable.
+
 #### Loops
 
 Loops repeat parts of the document.

--- a/lib/sablon/operations.rb
+++ b/lib/sablon/operations.rb
@@ -25,6 +25,21 @@ module Sablon
       end
     end
 
+    class OperatorCondition < Struct.new(:conditon_expr, :block, :operation)
+      def evaluate(env)
+        value = conditon_expr.evaluate(env.context)
+        if truthy?(operation[0..1], operation[2..-1].tr("'", ""), value.to_s)
+          block.replace(block.process(env).reverse)
+        else
+          block.replace([])
+        end
+      end
+
+      def truthy?(operation, value_a, value_b)
+        return (operation == "!=") ? (value_a != value_b) : (value_a == value_b) 
+      end
+    end
+
     class Condition < Struct.new(:conditon_expr, :block, :predicate)
       def evaluate(env)
         value = conditon_expr.evaluate(env.context)

--- a/lib/sablon/processor/document.rb
+++ b/lib/sablon/processor/document.rb
@@ -165,6 +165,9 @@ module Sablon
           when /([^ ]+):each\(([^ ]+)\)/
             block = consume_block("#{$1}:endEach")
             Statement::Loop.new(Expression.parse($1), $2, block)
+          when /([^ ]+):if\(((==|!=)(\d|'[\s\S]+')+)\)/
+            block = consume_block("#{$1}:endIf")
+            Statement::OperatorCondition.new(Expression.parse($1), block, $2)
           when /([^ ]+):if\(([^)]+)\)/
             block = consume_block("#{$1}:endIf")
             Statement::Condition.new(Expression.parse($1), block, $2)

--- a/test/fixtures/xml/conditional_with_equality_operator.xml
+++ b/test/fixtures/xml/conditional_with_equality_operator.xml
@@ -1,0 +1,38 @@
+<w:p>
+  <w:fldSimple w:instr=" MERGEFIELD middle_name:if(=='John') \* MERGEFORMAT ">
+    <w:r>
+      <w:rPr><w:noProof/></w:rPr>
+      <w:t>«middle_name:if(=='John')»</w:t>
+    </w:r>
+  </w:fldSimple>
+</w:p>
+<w:p>
+  <w:t>some content</w:t>
+</w:p>
+<w:p>
+  <w:fldSimple w:instr=" MERGEFIELD middle_name:endIf \* MERGEFORMAT ">
+    <w:r>
+      <w:rPr><w:noProof/></w:rPr>
+      <w:t>«middle_name:endIf»</w:t>
+    </w:r>
+  </w:fldSimple>
+</w:p>
+<w:p>
+  <w:fldSimple w:instr=" MERGEFIELD age:if(!=99) \* MERGEFORMAT ">
+    <w:r>
+      <w:rPr><w:noProof/></w:rPr>
+      <w:t>age:if(!=12)»</w:t>
+    </w:r>
+  </w:fldSimple>
+</w:p>
+<w:p>
+  <w:t>some content</w:t>
+</w:p>
+<w:p>
+  <w:fldSimple w:instr=" MERGEFIELD age:endIf \* MERGEFORMAT ">
+    <w:r>
+      <w:rPr><w:noProof/></w:rPr>
+      <w:t>«age:endIf»</w:t>
+    </w:r>
+  </w:fldSimple>
+</w:p>

--- a/test/processor/document_test.rb
+++ b/test/processor/document_test.rb
@@ -435,6 +435,18 @@ class ProcessorDocumentTest < Sablon::TestCase
     assert_equal "", text(result)
   end
 
+  def test_conditional_with_equality_operator
+    result = process(snippet("conditional_with_equality_operator"), {"middle_name" => "John", "age" => 45})  
+    assert_xml_equal <<-document, result
+        <w:p>
+          <w:t>some content</w:t>
+        </w:p>
+        <w:p>
+          <w:t>some content</w:t>
+        </w:p>
+    document
+  end
+
   def test_comment
     result = process(snippet("comment"), {})
     assert_equal "Before After", text(result)


### PR DESCRIPTION
I needed a simple way to add text depending on the value of the conditional, so I added this functionality.

It works like this:

```
«technology:if(=='Ruby')»
    ... arbitrary document markup ...
«technologies:endIf»

«age:if(!=45)»
    ... arbitrary document markup ...
«age:endIf»
```

I modified the README as well and also added a test case. Feedback? Thanks