### PR TITLE
Update dev dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.3)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     rake (12.3.0)
     rubyzip (1.2.1)
     xml-simple (1.1.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     mini_portile2 (2.2.0)
-    minitest (5.8.0)
+    minitest (5.10.3)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
-    rake (10.4.2)
+    rake (12.3.0)
     rubyzip (1.2.1)
     xml-simple (1.1.5)
 
@@ -22,9 +22,9 @@ PLATFORMS
 DEPENDENCIES
   bundler (>= 1.6)
   minitest (~> 5.4)
-  rake (~> 10.0)
+  rake (~> 12.0)
   sablon!
   xml-simple
 
 BUNDLED WITH
-   1.14.6
+   1.16.0

--- a/lib/sablon/configuration/html_tag.rb
+++ b/lib/sablon/configuration/html_tag.rb
@@ -34,6 +34,8 @@ module Sablon
         # Set basic params converting some args to symbols for consistency
         @name = name.to_sym
         @type = type.to_sym
+        @ast_class = nil
+        # use self.ast_class to trigger setter method
         self.ast_class = ast_class if ast_class
 
         # Ensure block level tags have an AST class

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -53,6 +53,7 @@ module Sablon
       end
 
       def initialize(_env, _node, _properties)
+        @properties ||= nil
         @attributes ||= {}
       end
 
@@ -169,6 +170,8 @@ module Sablon
     class Collection < Node
       attr_reader :nodes
       def initialize(nodes)
+        @properties ||= nil
+        @attributes ||= {}
         @nodes = nodes
       end
 
@@ -255,6 +258,7 @@ module Sablon
         # intialize values
         @list_tag = node.name
         #
+        @definition = nil
         if node.ancestors(".//#{@list_tag}").length.zero?
           # Only register a definition when upon the first list tag encountered
           @definition = env.numbering.register(properties[:pStyle])
@@ -368,7 +372,10 @@ module Sablon
 
     # Creates a blank line in the word document
     class Newline < Run
-      def initialize(*); end
+      def initialize(*)
+        @properties = nil
+        @attributes = {}
+      end
 
       def inspect
         "<Newline>"

--- a/lib/sablon/processor/document.rb
+++ b/lib/sablon/processor/document.rb
@@ -69,7 +69,7 @@ module Sablon
         end
 
         def remove_control_elements
-          body.each &:remove
+          body.each(&:remove)
           start_node.remove
           end_node.remove
         end
@@ -123,7 +123,7 @@ module Sablon
         end
 
         def remove_control_elements
-          body.each &:remove
+          body.each(&:remove)
           start_field.remove
           end_field.remove
         end

--- a/sablon.gemspec
+++ b/sablon.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = Sablon::VERSION
   spec.authors       = ["Yves Senn"]
   spec.email         = ["yves.senn@gmail.com"]
-  spec.summary       = %q{docx tempalte processor}
+  spec.summary       = %q{docx template processor}
   spec.description   = %q{Sablon is a document template processor. At this time it works only with docx and MailMerge fields.}
   spec.homepage      = "http://github.com/senny/sablon"
   spec.license       = "MIT"

--- a/sablon.gemspec
+++ b/sablon.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rubyzip', ">= 1.1.1"
 
   spec.add_development_dependency "bundler", ">= 1.6"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "minitest", "~> 5.4"
   spec.add_development_dependency "xml-simple"
 end

--- a/test/environment_test.rb
+++ b/test/environment_test.rb
@@ -6,8 +6,8 @@ class EnvironmentTest < Sablon::TestCase
     context = Sablon::Context.transform_hash(a: 1, b: { c: 2, "d" => 3 })
     env = Sablon::Environment.new(nil, a: 1, b: { c: 2, "d" => 3 })
     #
-    assert_equal(env.template, nil)
-    assert_equal(context, env.context)
+    assert_nil env.template
+    assert_equal context, env.context
   end
 
   def test_alter_context

--- a/test/expression_test.rb
+++ b/test/expression_test.rb
@@ -55,7 +55,7 @@ class LookupOrMethodCallTest < Sablon::TestCase
   def test_missing_receiver
     user = OpenStruct.new(first_name: "Jack")
     expr = Sablon::Expression.parse("user.address.line_1")
-    assert_equal nil, expr.evaluate("user" => user)
-    assert_equal nil, expr.evaluate({})
+    assert_nil expr.evaluate("user" => user)
+    assert_nil expr.evaluate({})
   end
 end

--- a/test/section_properties_test.rb
+++ b/test/section_properties_test.rb
@@ -34,7 +34,7 @@ class SectionPropertiesTest < Sablon::TestCase
 </w:body>
     documentxml
     properties = Sablon::Processor::SectionProperties.from_document(xml)
-    assert_equal nil, properties.start_page_number
+    assert_nil properties.start_page_number
     properties.start_page_number = "16"
     assert_equal "16", properties.start_page_number
   end


### PR DESCRIPTION
Updates the development dependencies to be more recent and updates some files that produced warnings or errors. (i.e. `assert_equal nil value` => `assert_nil  value` in test suite). I may also remove the Gemfile.lock depending on #75. 