### PR TITLE
Convert config props to strings

### DIFF
--- a/lib/sablon/configuration/html_tag.rb
+++ b/lib/sablon/configuration/html_tag.rb
@@ -49,7 +49,7 @@ module Sablon
         # etc. All the keys need to be symbols to avoid getting reparsed
         # with the element's CSS attributes.
         @properties = options.fetch(:properties, {})
-        @properties = Hash[@properties.map { |k, v| [k.to_sym, v] }]
+        @properties = Hash[@properties.map { |k, v| [k.to_s, v] }]
         # Set permitted child tags or tag groups
         self.allowed_children = options[:allowed_children]
       end

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -208,7 +208,7 @@ module Sablon
         @definition = nil
         if node.ancestors(".//#{@list_tag}").length.zero?
           # Only register a definition upon the first list tag encountered
-          @definition = env.document.add_list_definition(properties[:pStyle])
+          @definition = env.document.add_list_definition(properties['pStyle'])
         end
 
         # update attributes of all child nodes

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -30,8 +30,11 @@ module Sablon
         # process the styles as a hash and store values
         style_attrs = {}
         properties.each do |key, value|
+          key = key.strip if key.respond_to? :strip
+          value = value.strip if value.respond_to? :strip
+          #
           unless key.is_a? Symbol
-            key, value = *convert_style_property(key.strip, value.strip)
+            key, value = *convert_style_property(key, value)
           end
           style_attrs[key] = value if key
         end

--- a/lib/sablon/html/node_properties.rb
+++ b/lib/sablon/html/node_properties.rb
@@ -35,11 +35,11 @@ module Sablon
       end
 
       def [](key)
-        @properties[key]
+        @properties[key.to_sym]
       end
 
       def []=(key, value)
-        @properties[key] = value
+        @properties[key.to_sym] = value
       end
 
       def to_docx
@@ -57,7 +57,7 @@ module Sablon
         #
         properties.each do |key, value|
           if whitelist.include? key.to_s
-            @properties[key] = value
+            @properties[key.to_sym] = value
           else
             @transferred_properties[key] = value
           end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -21,7 +21,7 @@ class ConfigurationTest < Sablon::TestCase
     assert_equal :inline, tag.type
     assert_equal Sablon::HTMLConverter::Paragraph, tag.ast_class
     assert_equal({ dummy: 'value' }, tag.attributes)
-    assert_equal({ pstyle: 'ListBullet' }, tag.properties)
+    assert_equal({ 'pstyle' => 'ListBullet' }, tag.properties)
     assert_equal %i[_inline ol ul li], tag.allowed_children
 
     # test initialization with type
@@ -93,7 +93,7 @@ class ConfigurationHTMLTagTest < Sablon::TestCase
     assert_equal :inline, tag.type
     assert_equal Sablon::HTMLConverter::Run, tag.ast_class
     assert_equal({ dummy: 'value1' }, tag.attributes)
-    assert_equal({ dummy2: 'value2' }, tag.properties)
+    assert_equal({ 'dummy2' => 'value2' }, tag.properties)
     assert_equal [:text], tag.allowed_children
   end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -16,24 +16,24 @@ class ConfigurationTest < Sablon::TestCase
     }
     # test initialization without type
     tag = @config.register_html_tag(:test_tag, **options)
-    assert_equal @config.permitted_html_tags[:test_tag], tag
-    assert_equal tag.name, :test_tag
-    assert_equal tag.type, :inline
-    assert_equal tag.ast_class, Sablon::HTMLConverter::Paragraph
-    assert_equal tag.attributes, dummy: 'value'
-    assert_equal tag.properties, pstyle: 'ListBullet'
-    assert_equal tag.allowed_children, %i[_inline ol ul li]
+    assert_equal tag, @config.permitted_html_tags[:test_tag]
+    assert_equal :test_tag, tag.name
+    assert_equal :inline, tag.type
+    assert_equal Sablon::HTMLConverter::Paragraph, tag.ast_class
+    assert_equal({ dummy: 'value' }, tag.attributes)
+    assert_equal({ pstyle: 'ListBullet' }, tag.properties)
+    assert_equal %i[_inline ol ul li], tag.allowed_children
 
     # test initialization with type
     tag = @config.register_html_tag('test_tag2', :block, **options)
-    assert_equal @config.permitted_html_tags[:test_tag2], tag
-    assert_equal tag.name, :test_tag2
-    assert_equal tag.type, :block
+    assert_equal tag, @config.permitted_html_tags[:test_tag2]
+    assert_equal :test_tag2, tag.name
+    assert_equal :block, tag.type
   end
 
   def test_remove_tag
     tag = @config.register_html_tag(:test)
-    assert_equal @config.remove_html_tag(:test), tag
+    assert_equal tag, @config.remove_html_tag(:test)
     assert_nil @config.permitted_html_tags[:test]
   end
 
@@ -77,9 +77,9 @@ class ConfigurationHTMLTagTest < Sablon::TestCase
   def test_html_tag_full_init
     args = ['a', 'inline', ast_class: Sablon::HTMLConverter::Run]
     tag = Sablon::Configuration::HTMLTag.new(*args)
-    assert_equal tag.name, :a
-    assert_equal tag.type, :inline
-    assert_equal tag.ast_class, Sablon::HTMLConverter::Run
+    assert_equal :a, tag.name
+    assert_equal :inline, tag.type
+    assert_equal Sablon::HTMLConverter::Run, tag.ast_class
     #
     options = {
       ast_class: :run,
@@ -89,12 +89,12 @@ class ConfigurationHTMLTagTest < Sablon::TestCase
     }
     tag = Sablon::Configuration::HTMLTag.new('a', 'inline', **options)
     #
-    assert_equal tag.name, :a
-    assert_equal tag.type, :inline
-    assert_equal tag.ast_class, Sablon::HTMLConverter::Run
-    assert_equal tag.attributes, dummy: 'value1'
-    assert_equal tag.properties, dummy2: 'value2'
-    assert_equal tag.allowed_children, [:text]
+    assert_equal :a, tag.name
+    assert_equal :inline, tag.type
+    assert_equal Sablon::HTMLConverter::Run, tag.ast_class
+    assert_equal({ dummy: 'value1' }, tag.attributes)
+    assert_equal({ dummy2: 'value2' }, tag.properties)
+    assert_equal [:text], tag.allowed_children
   end
 
   def test_html_tag_init_block_without_class
@@ -113,10 +113,10 @@ class ConfigurationHTMLTagTest < Sablon::TestCase
     # test default allowances
     assert div.allowed_child?(text) # all inline elements allowed
     assert div.allowed_child?(olist) # tag name is included even though it is bock leve
-    assert_equal div.allowed_child?(div), false # other block elms are not allowed
+    assert_equal false, div.allowed_child?(div) # other block elms are not allowed
 
     # test olist with allowances for all blocks but no inline
     assert olist.allowed_child?(div) # all block elements allowed
-    assert_equal olist.allowed_child?(text), false # no inline elements
+    assert_equal false, olist.allowed_child?(text) # no inline elements
   end
 end

--- a/test/html/node_properties_test.rb
+++ b/test/html/node_properties_test.rb
@@ -81,13 +81,13 @@ class NodePropertiesTest < Sablon::TestCase
     props = {}
     props = Sablon::HTMLConverter::NodeProperties.new('w:pPr', props, @inc_props.new)
     props['rStyle'] = 'FootnoteText'
-    assert_equal({ 'rStyle' => 'FootnoteText' }, props.instance_variable_get(:@properties))
+    assert_equal({ rStyle: 'FootnoteText' }, props.instance_variable_get(:@properties))
   end
 
   def test_properties_filtered_on_init
     props = { 'pStyle' => 'Paragraph', 'rStyle' => 'EndnoteText' }
     props = Sablon::HTMLConverter::NodeProperties.new('w:rPr', props, %w[rStyle])
-    assert_equal({ 'rStyle' => 'EndnoteText' }, props.instance_variable_get(:@properties))
+    assert_equal({ rStyle: 'EndnoteText' }, props.instance_variable_get(:@properties))
   end
 
   def test_transferred_properties


### PR DESCRIPTION
All properties assigned during HTML tag registration during config get their keys converted to strings regardless of the incoming type. During initialization of the NodeProperties every key that get stored in the `@properties` instance var is converted back to a symbol. For consistency and simplicity all access methods convert the key to a symbol.

Fixes #87 