### PR TITLE
Check if media file being added to document has an extension

### DIFF
--- a/lib/sablon/document_object_model/relationships.rb
+++ b/lib/sablon/document_object_model/relationships.rb
@@ -24,7 +24,10 @@ module Sablon
           # existing file
           define_method(:add_media) do |name, data, rel_attr|
             rel_attr[:Target] = "media/#{name}"
-            extension = name.match(/\.(\w+?)$/).to_a[1]
+            # This matches any characters after the last "." in the filename
+            unless (extension = name.match(/.+\.(.+?$)/).to_a[1])
+              raise ArgumentError, "Filename: '#{name}' has no discernable extension"
+            end
             type = rel_attr[:Type].match(%r{/(\w+?)$}).to_a[1] + "/#{extension}"
             #
             if @zip_contents["word/#{rel_attr[:Target]}"]

--- a/test/sablon_test.rb
+++ b/test/sablon_test.rb
@@ -174,5 +174,13 @@ class SablonImagesTest < Sablon::TestCase
 
     template.render_to_file @output_path, context
     assert_docx_equal @sample_path, @output_path
+
+    # try to render a document with an image that has no extension
+    trooper = Sablon.content(:image, im_data, filename: 'clone')
+    context = { items: [], trooper: trooper }
+    e = assert_raises ArgumentError do
+      template.render_to_file @output_path, context
+    end
+    assert_equal "Filename: 'clone' has no discernable extension", e.message
   end
 end


### PR DESCRIPTION
As far as I know MS word requires an extension to be provided for any
files in the media folder in order to set the content type. Previously
an image without an extension would be allowed which would cause a
corrupted document. This now raises an argument error. In theory
I could check for an extension during context transformation and
raise a ContextError instead but this was simpler and having this
present in the #add_media method means it will work for any media
added and not just images incase an end user extends Sablon's content
types.