### PR TITLE
Add rFonts to Run node properties

### DIFF
--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -480,7 +480,7 @@ module Sablon
     class Run < Node
       PROPERTIES = %w[b i caps color dstrike emboss imprint highlight outline
                       rStyle shadow shd smallCaps strike sz u vanish
-                      vertAlign].freeze
+                      vertAlign rFonts].freeze
 
       def initialize(_env, node, properties)
         super


### PR DESCRIPTION
Add rFonts to Run node properties, so that we can setup a custom style converter for font-family