### PR TITLE
preventing zero file size errors to be raised

### DIFF
--- a/lib/sablon/template.rb
+++ b/lib/sablon/template.rb
@@ -53,7 +53,7 @@ module Sablon
 
     def render(context, properties = {})
       # initialize environment
-      @document = Sablon::DOM::Model.new(Zip::File.open(@path))
+      @document = Sablon::DOM::Model.new(Zip::File.open(@path, !File.exists?(@path)))
       env = Sablon::Environment.new(self, context)
       env.section_properties = properties
       #


### PR DESCRIPTION
It raises zero size error cause the second param (create flag) is not added to the Zip::File.open call