### PR TITLE
update expected docx when env variable UPDATE_SNAPSHOT is defined

### DIFF
--- a/lib/sablon/test/assertions.rb
+++ b/lib/sablon/test/assertions.rb
@@ -1,7 +1,9 @@
 module Sablon
   module Test
     module Assertions
-      def assert_docx_equal(expected_path, actual_path)
+      def assert_docx_equal(expected_path, actual_path, update_expected=ENV['UPDATE_SNAPSHOT'])
+        FileUtils.cp(actual_path, expected_path) if update_expected
+        puts " > Snapshot updated: #{expected_path}" if update_expected
         #
         # Parse document archives and generate a diff
         xml_diffs = diff_docx_files(expected_path, actual_path)


### PR DESCRIPTION
When making changes to a docx generation test, it is necessary to update
the expected output. This change makes it easy to do so without
requiring any additional code by simply defining the `UPDATE_SNAPSHOT`
when executing tests.

For example:

```
UPDATE_SNAPSHOT=1 bundle exec rake TEST=test/executable_test.rb
```

Inspired by Jest's `--updateSnapshot` command and snapshot testing model:

- https://jestjs.io/docs/en/snapshot-testing

NB: `assert_docx_equal` will always pass when `UPDATE_SNAPSHOT` is set.