### PR TITLE
gems, upgrade nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.1)
     minitest (5.14.4)
-    nokogiri (1.10.8)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.4)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    racc (1.5.2)
     rake (13.0.3)
     rubyzip (2.3.0)
     xml-simple (1.1.8)


### PR DESCRIPTION
Tried to upgrade Nokogiri but ended up with a test error that I'm not completely sure how to resolve:

```
  1) Error:
ContentWordMLTest#test_inserting_word_ml_multiple_times_into_same_paragraph:
RuntimeError: Cannot add sibling to a node with no parent
    /Users/senny/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/nokogiri-1.11.4-x86_64-darwin/lib/nokogiri/xml/node.rb:1183:in `add_sibling'
    /Users/senny/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/nokogiri-1.11.4-x86_64-darwin/lib/nokogiri/xml/node.rb:202:in `add_next_sibling'
    /Users/senny/Projects/sablon/lib/sablon/content.rb:134:in `block in add_siblings_to'
    /Users/senny/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/nokogiri-1.11.4-x86_64-darwin/lib/nokogiri/xml/node_set.rb:239:in `block in each'
    /Users/senny/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/nokogiri-1.11.4-x86_64-darwin/lib/nokogiri/xml/node_set.rb:238:in `upto'
    /Users/senny/.asdf/installs/ruby/2.6.6/lib/ruby/gems/2.6.0/gems/nokogiri-1.11.4-x86_64-darwin/lib/nokogiri/xml/node_set.rb:238:in `each'
    /Users/senny/Projects/sablon/lib/sablon/content.rb:133:in `add_siblings_to'
    /Users/senny/Projects/sablon/lib/sablon/content.rb:85:in `append_to'
    /Users/senny/Projects/sablon/test/content_test.rb:201:in `test_inserting_word_ml_multiple_times_into_same_paragraph'
```

The test that fails looks like this:
https://github.com/senny/sablon/blob/883de2ecb8c0e8fe92b549ca654f444160f67561/test/content_test.rb#L197-L217

The part where it's failing like this:
https://github.com/senny/sablon/blob/883de2ecb8c0e8fe92b549ca654f444160f67561/lib/sablon/content.rb#L132-L139

I suspect that this is related to the `.remove` here:
https://github.com/senny/sablon/blob/883de2ecb8c0e8fe92b549ca654f444160f67561/lib/sablon/content.rb#L89