### PR TITLE
Improve jruby support of ComplexFields

### DIFF
--- a/lib/sablon/parser/mail_merge.rb
+++ b/lib/sablon/parser/mail_merge.rb
@@ -86,7 +86,7 @@ module Sablon
         end
 
         def separate_node
-          @nodes.detect {|n| !n.search(".//w:fldChar[@w:fldCharType='separate']").empty? }
+          @nodes.detect {|n| !n.search(".//w:fldChar[@*[local-name()='fldCharType' and .='separate']]").empty? }
         end
       end
 
@@ -147,7 +147,7 @@ module Sablon
       def build_complex_field(node)
         possible_field_node = node.parent
         field_nodes = [possible_field_node]
-        while possible_field_node && possible_field_node.search(".//w:fldChar[@w:fldCharType='end']").empty?
+        while possible_field_node && possible_field_node.search(".//w:fldChar[@*[local-name()='fldCharType' and .='end']]").empty?
           possible_field_node = possible_field_node.next_element
           field_nodes << possible_field_node
         end


### PR DESCRIPTION
Due to underlying differences in the jruby and MRI xml libraries in nokogiri, sablon doesn't currently work well in jruby. This PR improves the situation by fixing the ComplexField class in mail_merge.rb.

Currently the ComplexField class contains xpath searches that use namespaced attributes in the search expression, which appears to not work in jruby/nokogiri. Using local-name and ignoring the attribute namespace appears to work well for both jruby and MRI.