### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,13 +8,15 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    mini_portile2 (2.4.0)
-    minitest (5.14.4)
-    nokogiri (1.10.8)
-      mini_portile2 (~> 2.4.0)
-    rake (13.0.3)
-    rubyzip (2.3.0)
-    xml-simple (1.1.8)
+    minitest (5.20.0)
+    nokogiri (1.15.5)
+      racc (~> 1.4)
+    racc (1.7.3)
+    rake (13.1.0)
+    rexml (3.2.6)
+    rubyzip (2.3.2)
+    xml-simple (1.1.9)
+      rexml
 
 PLATFORMS
   ruby
@@ -27,4 +29,4 @@ DEPENDENCIES
   xml-simple
 
 BUNDLED WITH
-   1.17.2
+   2.4.15

--- a/lib/sablon/content.rb
+++ b/lib/sablon/content.rb
@@ -130,11 +130,16 @@ module Sablon
       # node passed in. Run properties are merged here because of namespace
       # issues when working with a document fragment
       def add_siblings_to(node, rpr_tag = nil)
-        xml.children.reverse.each do |child|
-          node.add_next_sibling child
-          # merge properties
-          next unless rpr_tag
-          merge_rpr_tags(child, rpr_tag.children)
+        # Since Nokogiri 1.11.0 adding siblings is only possible for nodes
+        # with a parent because the parent is used as the context node for
+        # parsing markup.
+        if !node.parent.nil?
+          xml.children.reverse.each do |child|
+            node.add_next_sibling child
+            # merge properties
+            next unless rpr_tag
+            merge_rpr_tags(child, rpr_tag.children)
+          end
         end
       end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -75,8 +75,9 @@ class ConfigurationHTMLTagTest < Sablon::TestCase
 
   # Exercising more of the logic used to conform args into valid
   def test_html_tag_full_init
-    args = ['a', 'inline', ast_class: Sablon::HTMLConverter::Run]
-    tag = Sablon::Configuration::HTMLTag.new(*args)
+    args = ['a', 'inline']
+    kwargs = { ast_class: Sablon::HTMLConverter::Run }
+    tag = Sablon::Configuration::HTMLTag.new(*args, **kwargs)
     assert_equal :a, tag.name
     assert_equal :inline, tag.type
     assert_equal Sablon::HTMLConverter::Run, tag.ast_class

--- a/test/html/ast_builder_test.rb
+++ b/test/html/ast_builder_test.rb
@@ -39,7 +39,7 @@ class HTMLConverterASTBuilderTest < Sablon::TestCase
   def test_merge_properties
     @builder = new_builder
     node = Nokogiri::HTML.fragment('<span style="color: #F00; text-decoration: underline wavy">Test</span>').children[0]
-    tag = Struct.new(:properties).new(rStyle: 'Normal')
+    tag = Struct.new(:properties).new({ rStyle: 'Normal' })
     # test that properties are merged across all three arguments
     props = @builder.send(:merge_node_properties, node, tag, 'background-color' => '#00F')
     assert_equal({ 'background-color' => '#00F', rStyle: 'Normal', 'color' => '#F00', 'text-decoration' => 'underline wavy' }, props)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,7 @@ $: << File.expand_path('../../lib', __FILE__)
 require "sablon"
 require "sablon/test/assertions"
 
-class Sablon::TestCase < MiniTest::Test
+class Sablon::TestCase < Minitest::Test
   include Sablon::Test::Assertions
 
   def teardown


### PR DESCRIPTION
Update dependencies to latest versions and fix Ruby 3 compatibility issues.
Tested with Ruby 3.2.