### PR TITLE
Drop Ruby 2.2 and move to GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,10 +12,10 @@ permissions:
 jobs:
   test:
     name: Tests
-    runs-on: ${{ matrix.ruby < '2.3' && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        ruby-version: ['2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
         channel: ['stable']
 
         include:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,38 @@
+name: Ruby tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ${{ matrix.ruby < '2.3' && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    strategy:
+      matrix:
+        ruby-version: ['2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        channel: ['stable']
+
+        include:
+          - ruby-version: 'head'
+            channel: 'experimental'
+
+    env:
+      BUNDLE_GEMFILE: gemfiles/ci.gemfile
+
+    continue-on-error: ${{ matrix.channel != 'stable' }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+    - name: Run tests
+      run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-before_install:
-  - gem install bundler:1.17.2
-language: ruby
-rvm:
-  - 2.6
-  - 2.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,9 +8,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    mini_portile2 (2.8.7)
     minitest (5.20.0)
+    nokogiri (1.16.5)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.16.5-arm64-darwin)
       racc (~> 1.4)
+    ostruct (0.6.0)
     racc (1.8.0)
     rake (13.1.0)
     rexml (3.2.6)
@@ -19,11 +24,12 @@ GEM
       rexml
 
 PLATFORMS
-  arm64-darwin-23
+  arm64-darwin
 
 DEPENDENCIES
   bundler (>= 1.6)
   minitest (~> 5.4)
+  ostruct
   rake (~> 13.0)
   sablon!
   xml-simple

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sablon
 
 [![Gem Version](https://badge.fury.io/rb/sablon.svg)](http://badge.fury.io/rb/sablon)
-[![Build Status](https://travis-ci.org/senny/sablon.svg?branch=master)](https://travis-ci.org/senny/sablon)
+[![Build Status](https://github.com/senny/sablon/actions/workflows/ruby.yml/badge.svg)](https://github.com/senny/sablon/actions)
 
 Is a document template processor for Word `docx` files. It leverages Word's
 built-in formatting and layouting capabilities to make template creation easy

--- a/gemfiles/ci.gemfile
+++ b/gemfiles/ci.gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec path: "../"

--- a/sablon.gemspec
+++ b/sablon.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.2'
+  spec.required_ruby_version = '>= 2.3'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 

--- a/sablon.gemspec
+++ b/sablon.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.4"
   spec.add_development_dependency "xml-simple"
+  spec.add_development_dependency "ostruct"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require "minitest/mock"
 require "xmlsimple"
 require "json"
 require "pathname"
+require "ostruct"
 
 $: << File.expand_path('../../lib', __FILE__)
 require "sablon"


### PR DESCRIPTION
- Test against all supported Ruby versions
- Test ruby-head as experimental
- Use a gemfile specific for CI to avoid issues with committed Gemfile.lock