### PR TITLE
Fix typos in non-production code

### DIFF
--- a/lib/sablon/content.rb
+++ b/lib/sablon/content.rb
@@ -143,7 +143,7 @@ module Sablon
         end
       end
 
-      # Merges the provided properties into the run proprties of the
+      # Merges the provided properties into the run properties of the
       # node passed in. Properties are only added if they are not already
       # defined on the node itself.
       def merge_rpr_tags(node, props)

--- a/lib/sablon/document_object_model/model.rb
+++ b/lib/sablon/document_object_model/model.rb
@@ -68,7 +68,7 @@ module Sablon
         end
       end
 
-      # constructs the dom model using helper clases defined under this
+      # constructs the dom model using helper classes defined under this
       # namespace.
       def build_dom(entries)
         key_values = entries.map do |entry_name, content|

--- a/lib/sablon/document_object_model/relationships.rb
+++ b/lib/sablon/document_object_model/relationships.rb
@@ -12,7 +12,7 @@ module Sablon
           #
           # adds a relationship to the rels file for the current entry
           define_method(:add_relationship) do |rel_attr|
-            # detemine name of rels file to augment
+            # determine name of rels file to augment
             rels_name = Relationships.rels_entry_name_for(@current_entry)
 
             # create the file if needed and update DOM

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -42,7 +42,7 @@ module Sablon
       end
 
       # handles conversion of a single attribute allowing recursion through
-      # super classes. If the key exists and conversion is succesful a
+      # super classes. If the key exists and conversion is successful a
       # symbol is returned to avoid conflicts with a CSS prop sharing the
       # same name. Keys without a conversion class are returned as is
       def self.convert_style_property(key, value)
@@ -88,7 +88,7 @@ module Sablon
         ' ' + @attributes.map { |k, v| %(#{k}="#{v}") }.join(' ')
       end
 
-      # Acts like an abstract method allowing subclases full flexibility to
+      # Acts like an abstract method allowing subclasses full flexibility to
       # define any content inside the tags.
       def children_to_docx
         ''
@@ -205,7 +205,7 @@ module Sablon
     # Manages the child nodes of a list type tag
     class List < Collection
       def initialize(env, node, properties)
-        # intialize values
+        # initialize values
         @list_tag = node.name
         #
         @definition = nil

--- a/lib/sablon/html/ast_builder.rb
+++ b/lib/sablon/html/ast_builder.rb
@@ -72,7 +72,7 @@ module Sablon
 
       # If the node doesn't allow inline elements, or text specifically,
       # drop all text nodes. This is largely meant to prevent whitespace
-      # between tags from rasing an invalid structure error. Although it
+      # between tags from raising an invalid structure error. Although it
       # will purge the node whether it contains nonblank characters or not.
       def drop_text?(child)
         text = fetch_tag(:text)

--- a/lib/sablon/html/node_properties.rb
+++ b/lib/sablon/html/node_properties.rb
@@ -50,7 +50,7 @@ module Sablon
 
       # processes properties adding those on the whitelist to the
       # properties instance variable and those not to the transferred_properties
-      # isntance variable
+      # instance variable
       def filter_properties(properties, whitelist)
         @transferred_properties = {}
         @properties = {}

--- a/lib/sablon/processor/document.rb
+++ b/lib/sablon/processor/document.rb
@@ -12,7 +12,7 @@ module Sablon
         # passed in should be an instance of the Handler class or implement
         # the same interface. Handlers cannot be replaced by this method,
         # instead the `replace_field_handler` method should be used which
-        # internally removes the existing hander and registers the one passed
+        # internally removes the existing handler and registers the one passed
         # in. The name 'default' is special and will be called if no other
         # handlers can use the provided field.
         def register_field_handler(name, handler)

--- a/lib/sablon/processor/document/blocks.rb
+++ b/lib/sablon/processor/document/blocks.rb
@@ -92,7 +92,7 @@ module Sablon
         end
 
         def replace(image)
-          # we need to include the start and end nodes incase the image is
+          # we need to include the start and end nodes in case the image is
           # inline with the merge fields
           nodes = [start_node] + body + [end_node]
           #

--- a/lib/sablon/processor/document/operation_construction.rb
+++ b/lib/sablon/processor/document/operation_construction.rb
@@ -41,7 +41,7 @@ module Sablon
         end
 
         # Creates multiple blocks based on the sub expression patterns supplied
-        # while searching for the end expresion. The start and end fields
+        # while searching for the end expression. The start and end fields
         # of adjacent blocks are shared. For example in an if-else-endif
         # block the else field is the end for the if clause block and the
         # start of the else clause block.

--- a/lib/sablon/template.rb
+++ b/lib/sablon/template.rb
@@ -65,7 +65,7 @@ module Sablon
       end
     end
 
-    # Processes all of te entries searching for ones that match the pattern.
+    # Processes all of the entries searching for ones that match the pattern.
     # The hash is converted into an array first to avoid any possible
     # modification during iteration errors (i.e. creation of a new rels file).
     def process(env)

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -113,7 +113,7 @@ class ConfigurationHTMLTagTest < Sablon::TestCase
 
     # test default allowances
     assert div.allowed_child?(text) # all inline elements allowed
-    assert div.allowed_child?(olist) # tag name is included even though it is bock leve
+    assert div.allowed_child?(olist) # tag name is included even though it is block level
     assert_equal false, div.allowed_child?(div) # other block elms are not allowed
 
     # test olist with allowances for all blocks but no inline

--- a/test/content_test.rb
+++ b/test/content_test.rb
@@ -203,7 +203,7 @@ class ContentWordMLTest < Sablon::TestCase
     Sablon.content(:word_ml, @word_ml).append_to @paragraph, @node, @env
 
     # Only a single insertion should work because the node that we insert
-    # the content afer contains a merge field that needs removed. That means
+    # the content after contains a merge field that needs removed. That means
     # in the next two appends the @node variable doesn't exist on the document
     # tree
     output = <<-XML.gsub(/^\s+|\n/, '')

--- a/test/custom_field_handler_test.rb
+++ b/test/custom_field_handler_test.rb
@@ -15,7 +15,7 @@ class SablonCustomFieldHandlerTest < Sablon::TestCase
         predicate = condition[:predicate]
         block = condition[:block]
         #
-        # determine valeu of conditional expression + predicate
+        # determine value of conditional expression + predicate
         value = eval_condition_expr(conditon_expr, predicate, env.context)
         #
         # manipulate block based on truthy-ness of value

--- a/test/html/ast_builder_test.rb
+++ b/test/html/ast_builder_test.rb
@@ -10,28 +10,28 @@ class HTMLConverterASTBuilderTest < Sablon::TestCase
   end
 
   def test_fetch_tag
-    @bulider = new_builder
+    @builder = new_builder
     tag = Sablon::Configuration.instance.permitted_html_tags[:span]
-    assert_equal @bulider.send(:fetch_tag, :span), tag
+    assert_equal @builder.send(:fetch_tag, :span), tag
     # check that strings are converted into symbols
-    assert_equal @bulider.send(:fetch_tag, 'span'), tag
-    # test uknown tag raises error
+    assert_equal @builder.send(:fetch_tag, 'span'), tag
+    # test unknown tag raises error
     e = assert_raises ArgumentError do
-      @bulider.send(:fetch_tag, :unknown_tag)
+      @builder.send(:fetch_tag, :unknown_tag)
     end
     assert_equal "Don't know how to handle HTML tag: unknown_tag", e.message
   end
 
   def test_validate_structure
-    @bulider = new_builder
+    @builder = new_builder
     root = Sablon::Configuration.instance.permitted_html_tags['#document-fragment'.to_sym]
     div = Sablon::Configuration.instance.permitted_html_tags[:div]
     span = Sablon::Configuration.instance.permitted_html_tags[:span]
     # test valid relationship
-    assert_nil @bulider.send(:validate_structure, div, span)
+    assert_nil @builder.send(:validate_structure, div, span)
     # test inverted relationship
     e = assert_raises ArgumentError do
-      @bulider.send(:validate_structure, span, div)
+      @builder.send(:validate_structure, span, div)
     end
     assert_equal "Invalid HTML structure: div is not a valid child element of span.", e.message
   end
@@ -43,7 +43,7 @@ class HTMLConverterASTBuilderTest < Sablon::TestCase
     # test that properties are merged across all three arguments
     props = @builder.send(:merge_node_properties, node, tag, 'background-color' => '#00F')
     assert_equal({ 'background-color' => '#00F', rStyle: 'Normal', 'color' => '#F00', 'text-decoration' => 'underline wavy' }, props)
-    # test that parent properties are overriden by tag properties
+    # test that parent properties are overridden by tag properties
     props = @builder.send(:merge_node_properties, node, tag, rStyle: 'Citation', 'background-color' => '#00F')
     assert_equal({ 'background-color' => '#00F', rStyle: 'Normal', 'color' => '#F00', 'text-decoration' => 'underline wavy' }, props)
     # test that inline properties override parent styles

--- a/test/html/converter_style_test.rb
+++ b/test/html/converter_style_test.rb
@@ -235,7 +235,7 @@ class HTMLConverterStyleTest < Sablon::TestCase
   end
 
   def test_conversion_of_a_registered_tag_without_ast_class
-    # This registers a new tag with the configuration object and then trys
+    # This registers a new tag with the configuration object and then tries
     # to convert it
     Sablon.configure do |config|
       config.register_html_tag(:bgcyan, :inline, properties: { 'highlight' => { val: 'cyan' } })

--- a/test/processor/document_test.rb
+++ b/test/processor/document_test.rb
@@ -76,9 +76,9 @@ class ProcessorDocumentTest < Sablon::TestCase
       assert !@processor.field_handlers.keys.include?(:test), 'handler was not removed from handlers hash'
       assert_equal handler, removed, 'handler should have been returned after removal'
       #
-      # try and remove a non-existant handler
+      # try and remove a non-existent handler
       removed = @processor.remove_field_handler '_i_do_not_exist_'
-      assert_nil removed, 'Removing a non-existant handler should just return nil'
+      assert_nil removed, 'Removing a non-existent handler should just return nil'
     end
   end
 
@@ -91,7 +91,7 @@ class ProcessorDocumentTest < Sablon::TestCase
     #
     # try and remove the default handler again
     removed = @processor.remove_field_handler :default
-    assert_nil removed, 'Removing a non-existant default handler should just return nil'
+    assert_nil removed, 'Removing a non-existent default handler should just return nil'
   end
 
 


### PR DESCRIPTION
Found with `codespell **/*.rb **/*.md` plus some manual fixes and manual findings.

Didn't fix `discernable` because it can be considered production code
and introduce a breaking change.