### PR TITLE
Add <del> tag support

### DIFF
--- a/lib/sablon/configuration/configuration.rb
+++ b/lib/sablon/configuration/configuration.rb
@@ -86,6 +86,7 @@ module Sablon
         i: { type: :inline, ast_class: nil, properties: { i: nil } },
         u: { type: :inline, ast_class: nil, properties: { u: 'single' } },
         s: { type: :inline, ast_class: nil, properties: { strike: 'true' } },
+        del: { type: :inline, ast_class: nil, properties: { strike: 'true' } },
         sub: { type: :inline, ast_class: nil, properties: { vertAlign: 'subscript' } },
         sup: { type: :inline, ast_class: nil, properties: { vertAlign: 'superscript' } },
 

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -478,7 +478,7 @@ module Sablon
     # Create a run of text in the document, runs cannot be nested within
     # each other
     class Run < Node
-      PROPERTIES = %w[b i caps color dstrike emboss imprint highlight outline
+      PROPERTIES = %w[b i caps color del dstrike emboss imprint highlight outline
                       rStyle shadow shd smallCaps strike sz u vanish
                       vertAlign rFonts].freeze
 

--- a/lib/sablon/version.rb
+++ b/lib/sablon/version.rb
@@ -1,3 +1,3 @@
 module Sablon
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end

--- a/test/html/converter_test.rb
+++ b/test/html/converter_test.rb
@@ -561,6 +561,22 @@ class HTMLConverterTest < Sablon::TestCase
     assert_match(/Don't know how to handle HTML tag:/, e.message)
   end
 
+  def test_convert_del_tags_inside_p
+    input = '<p>Lorem&nbsp;<del>ipsum dolor</del>&nbsp;sit amet</p>'
+    expected_output = <<-DOCX.strip
+      <w:p>
+        <w:pPr><w:pStyle w:val="Paragraph" /></w:pPr>
+        <w:r><w:t xml:space="preserve">Lorem </w:t></w:r>
+        <w:r>
+          <w:rPr><w:strike w:val="true" /></w:rPr>
+          <w:t xml:space="preserve">ipsum dolor</w:t>
+        </w:r>
+        <w:r><w:t xml:space="preserve"> sit amet</w:t></w:r>
+      </w:p>
+    DOCX
+    assert_equal normalize_wordml(expected_output), process(input)
+  end
+
   private
 
   def process(input)


### PR DESCRIPTION
Hi, I've been working with ActionText inputs which use `<del>` tag for strike text, and needed to paste ActionText input to the docx file using Sablon.