### PR TITLE
Fix Google Docs compatibility by suppressing Zip64 extra fields

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
         channel: ['stable']
 
         include:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     racc (1.8.1)
     rake (13.3.0)
     rexml (3.4.1)
-    rubyzip (3.0.1)
+    rubyzip (3.2.2)
     xml-simple (1.1.9)
       rexml
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     sablon (0.4.3)
       nokogiri (>= 1.8.5)
-      rubyzip (>= 1.3.0)
+      rubyzip (>= 2.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/sablon.gemspec
+++ b/sablon.gemspec
@@ -19,12 +19,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.add_runtime_dependency 'nokogiri', ">= 1.8.5"
-  spec.add_runtime_dependency 'rubyzip', ">= 1.3.0"
+  spec.add_runtime_dependency 'rubyzip', ">= 2.3.0"
 
   spec.add_development_dependency "bundler", ">= 1.6"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
rubyzip 3.x enables Zip64 by default, adding extra fields to zip entries that cause docx files to fail opening in Google Docs/Drive.

Suppress Zip64 extra fields using rubyzip 3.2.0's suppress_extra_fields option

For rubyzip 3.0/3.1 users, `Zip.write_zip64_support = false` can be used instead.

Closes https://github.com/senny/sablon/issues/207