### PR TITLE
Fix mixed-type nested lists (ul inside ol, ol inside ul) not rendered

### DIFF
--- a/lib/sablon/configuration/configuration.rb
+++ b/lib/sablon/configuration/configuration.rb
@@ -69,8 +69,8 @@ module Sablon
         h4: { type: :block, ast_class: :paragraph, properties: { pStyle: 'Heading4' }, allowed_children: :_inline },
         h5: { type: :block, ast_class: :paragraph, properties: { pStyle: 'Heading5' }, allowed_children: :_inline },
         h6: { type: :block, ast_class: :paragraph, properties: { pStyle: 'Heading6' }, allowed_children: :_inline },
-        ol: { type: :block, ast_class: :list, properties: { pStyle: 'ListNumber' }, allowed_children: %i[ol li] },
-        ul: { type: :block, ast_class: :list, properties: { pStyle: 'ListBullet' }, allowed_children: %i[ul li] },
+        ol: { type: :block, ast_class: :list, properties: { pStyle: 'ListNumber' }, allowed_children: %i[ol ul li] },
+        ul: { type: :block, ast_class: :list, properties: { pStyle: 'ListBullet' }, allowed_children: %i[ul ol li] },
         li: { type: :block, ast_class: :list_paragraph },
 
         # inline style tags for tables

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -256,8 +256,16 @@ module Sablon
       end
 
       # moves any list tags that are a child of a list item tag up one level
-      # so they become a sibling instead of a child
+      # so they become a sibling instead of a child, and unwraps block-level
+      # <p> tags directly inside <li> to prevent nested w:p in OOXML
       def process_child_nodes(node)
+        # Unwrap <p> directly inside <li>: editors such as Trix wrap list item
+        # text in <p>, but <li> already maps to w:p so nesting them produces
+        # invalid OOXML that Word silently drops.
+        node.xpath("./li/p").each do |p|
+          p.replace(p.children)
+        end
+
         node.xpath("./li/ul | ./li/ol").each do |list|
           # transfer attributes from parent now because the list tag will
           # no longer be a child and won't inheirit them as usual

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -258,7 +258,7 @@ module Sablon
       # moves any list tags that are a child of a list item tag up one level
       # so they become a sibling instead of a child
       def process_child_nodes(node)
-        node.xpath("./li/#{@list_tag}").each do |list|
+        node.xpath("./li/ul | ./li/ol").each do |list|
           # transfer attributes from parent now because the list tag will
           # no longer be a child and won't inheirit them as usual
           transfer_node_attributes(list.children, list.parent.attributes)

--- a/lib/sablon/html/ast.rb
+++ b/lib/sablon/html/ast.rb
@@ -256,16 +256,8 @@ module Sablon
       end
 
       # moves any list tags that are a child of a list item tag up one level
-      # so they become a sibling instead of a child, and unwraps block-level
-      # <p> tags directly inside <li> to prevent nested w:p in OOXML
+      # so they become a sibling instead of a child
       def process_child_nodes(node)
-        # Unwrap <p> directly inside <li>: editors such as Trix wrap list item
-        # text in <p>, but <li> already maps to w:p so nesting them produces
-        # invalid OOXML that Word silently drops.
-        node.xpath("./li/p").each do |p|
-          p.replace(p.children)
-        end
-
         node.xpath("./li/ul | ./li/ol").each do |list|
           # transfer attributes from parent now because the list tag will
           # no longer be a child and won't inheirit them as usual

--- a/test/html/ast_test.rb
+++ b/test/html/ast_test.rb
@@ -115,6 +115,24 @@ class HTMLConverterASTTest < Sablon::TestCase
     assert_equal %w[0 1 2 1 0 1 2], get_numpr_prop_from_ast(ast, :ilvl)
   end
 
+  def test_mixed_nested_list_ol_containing_ul
+    # an unordered list nested inside an ordered list should produce
+    # two visible list items, not just the outer item
+    input = '<ol><li>ordered1<ul><li>unordered2</li></ul></li></ol>'
+    ast = @converter.processed_ast(input)
+    assert_equal 2, get_numpr_prop_from_ast(ast, :ilvl).length
+    assert_equal %w[0 0], get_numpr_prop_from_ast(ast, :ilvl)
+  end
+
+  def test_mixed_nested_list_ul_containing_ol
+    # an ordered list nested inside an unordered list should produce
+    # two visible list items, not just the outer item
+    input = '<ul><li>bullet1<ol><li>ordered2</li></ol></li></ul>'
+    ast = @converter.processed_ast(input)
+    assert_equal 2, get_numpr_prop_from_ast(ast, :ilvl).length
+    assert_equal %w[0 0], get_numpr_prop_from_ast(ast, :ilvl)
+  end
+
   def test_table_tag
     input='<table></table>'
     ast = @converter.processed_ast(input)

--- a/test/html/ast_test.rb
+++ b/test/html/ast_test.rb
@@ -115,6 +115,14 @@ class HTMLConverterASTTest < Sablon::TestCase
     assert_equal %w[0 1 2 1 0 1 2], get_numpr_prop_from_ast(ast, :ilvl)
   end
 
+  def test_p_inside_li_is_unwrapped
+    # editors like Trix wrap <li> text in <p>; the <p> must be unwrapped
+    # because <li> already maps to w:p and OOXML forbids nested w:p elements
+    input = '<ul><li><p>item one</p></li><li><p>item two</p></li></ul>'
+    ast = @converter.processed_ast(input)
+    assert_equal '<Root: [<List: [<Paragraph{ListBullet}: [<Run{}: item one>]>, <Paragraph{ListBullet}: [<Run{}: item two>]>]>]>', ast.inspect
+  end
+
   def test_mixed_nested_list_ol_containing_ul
     # an unordered list nested inside an ordered list should produce
     # two visible list items, not just the outer item

--- a/test/html/ast_test.rb
+++ b/test/html/ast_test.rb
@@ -115,14 +115,6 @@ class HTMLConverterASTTest < Sablon::TestCase
     assert_equal %w[0 1 2 1 0 1 2], get_numpr_prop_from_ast(ast, :ilvl)
   end
 
-  def test_p_inside_li_is_unwrapped
-    # editors like Trix wrap <li> text in <p>; the <p> must be unwrapped
-    # because <li> already maps to w:p and OOXML forbids nested w:p elements
-    input = '<ul><li><p>item one</p></li><li><p>item two</p></li></ul>'
-    ast = @converter.processed_ast(input)
-    assert_equal '<Root: [<List: [<Paragraph{ListBullet}: [<Run{}: item one>]>, <Paragraph{ListBullet}: [<Run{}: item two>]>]>]>', ast.inspect
-  end
-
   def test_mixed_nested_list_ol_containing_ul
     # an unordered list nested inside an ordered list should produce
     # two visible list items, not just the outer item


### PR DESCRIPTION
## Problem

When a list of one type is nested inside a list item of a different type (e.g. `<ul>` inside `<ol><li>`, or `<ol>` inside `<ul><li>`), the nested list items are silently dropped from the generated `.docx` output. Only the outer list item is visible.

Example input:
```html
<ol>
  <li>ordered1
    <ul>
      <li>unordered2</li>
    </ul>
  </li>
</ol>
```

Expected output: two list items visible in the document.
Actual output: only `ordered1` appears; `unordered2` is dropped.

Fixes #197.

## Root cause

Two bugs combined to cause this:

**1. `process_child_nodes` in `AST::List` (`lib/sablon/html/ast.rb`)**

The XPath `./li/#{@list_tag}` only matched nested lists of the **same** type as the parent (e.g. `ol` inside `ol`, `ul` inside `ul`). A mixed-type nested list was never promoted to sibling level, so its items remained as children of a `<w:p>`, producing invalid OOXML that Word silently drops.

**2. `allowed_children` for `ol` and `ul` (`lib/sablon/configuration/configuration.rb`)**

`ol` only permitted `[ol, li]` as children, and `ul` only permitted `[ul, li]`. After fixing (1), the promoted sibling would fail structure validation with _"ol is not a valid child element of ul"_.

## Fix

- Change the XPath from `./li/#{@list_tag}` to `./li/ul | ./li/ol` so both list types are promoted regardless of parent type.
- Add `ul` to `ol`'s `allowed_children` and `ol` to `ul`'s `allowed_children`.

## Tests

Two regression tests added covering both directions of mixed nesting.